### PR TITLE
fix(hooks): the round cap must refuse a PR target it cannot read

### DIFF
--- a/changelog.d/20260908203528-fixed-codex-round-cap-unresolvable-target.md
+++ b/changelog.d/20260908203528-fixed-codex-round-cap-unresolvable-target.md
@@ -1,10 +1,8 @@
-- **A Codex round request whose PR number is not written literally is now
-  refused instead of skipping the round cap.** The cap counts a PR's existing
-  Codex reviews and blocks a further round until a conscious
-  `# escalation-ack`, but it resolves the PR from the command text — and a
-  `PreToolUse` hook sees that text *before* the shell expands anything. A target
-  like `$n`, `"$PR"` or `$(…)` therefore resolved to nothing, and the gate
-  skipped that segment entirely rather than refusing it.
+- **A Codex round request is now refused unless the hook can read which pull
+  request it names.** The cap counts a PR's existing Codex reviews and blocks a
+  further round until a conscious `# escalation-ack`, but it resolves the PR
+  from the command text — and a `PreToolUse` hook sees that text *before* the
+  shell expands anything. Any identity it could not read simply skipped the cap.
 
   Measured: writing the request as
   `for n in 1625 1576 1609; do gh pr comment $n --body "@codex review"; done`
@@ -13,9 +11,23 @@
   force. The same request written with a literal number was refused correctly,
   so the cap was doing its job whenever it could tell which PR it was reading.
 
-  Only an *unexpanded expansion* fails closed. A missing target and a literal
-  branch name keep their documented fail-open: both are knowable in principle,
-  whereas an expansion's value does not exist yet at hook time. The
-  acknowledgement sigil deliberately does not clear this refusal either — it is
-  computed across the whole command, so one sigil on a loop would otherwise
-  license a round on every pull request the loop touched.
+  Both identity-bearing values are now covered — the PR target *and* the
+  repository (`--repo`/`-R`, or the owner/repo inside a URL target); with a
+  literal number and an unreadable repo the count went to a nonexistent API
+  path, errored, and failed open. Each is accepted by an **allowlist** of what
+  gh documents (`[<number> | <url> | <branch>]`, `[HOST/]OWNER/REPO`), spelled
+  in characters the shell does not act on, so a spelling nobody thought of is
+  refused by construction rather than added to a list next time.
+
+  What this costs, since it will be met in normal use: the common
+  `gh pr comment 1234 --repo "$SLUG" --body "@codex review"` now needs the slug
+  written out (or dropped, when running inside the repo). Measured over 530
+  distinct real round requests, 47 (8.9%) are refused; in that corpus every one
+  of them is a request whose PR or repository the cap genuinely could not read.
+  A PR URL keeps working as copied from a browser, `/files`, `#issuecomment-…`
+  and all.
+
+  Two fail-opens are deliberately kept: a request with no positional target at
+  all, and a literal branch name. The acknowledgement sigil does not clear this
+  refusal either — it is computed across the whole command, so one sigil on a
+  loop would license a round on every pull request the loop touched.

--- a/changelog.d/20260908203528-fixed-codex-round-cap-unresolvable-target.md
+++ b/changelog.d/20260908203528-fixed-codex-round-cap-unresolvable-target.md
@@ -1,0 +1,21 @@
+- **A Codex round request whose PR number is not written literally is now
+  refused instead of skipping the round cap.** The cap counts a PR's existing
+  Codex reviews and blocks a further round until a conscious
+  `# escalation-ack`, but it resolves the PR from the command text — and a
+  `PreToolUse` hook sees that text *before* the shell expands anything. A target
+  like `$n`, `"$PR"` or `$(…)` therefore resolved to nothing, and the gate
+  skipped that segment entirely rather than refusing it.
+
+  Measured: writing the request as
+  `for n in 1625 1576 1609; do gh pr comment $n --body "@codex review"; done`
+  posted round requests against two pull requests already at or past the cap,
+  with no acknowledgement and none of the step-back triage the block exists to
+  force. The same request written with a literal number was refused correctly,
+  so the cap was doing its job whenever it could tell which PR it was reading.
+
+  Only an *unexpanded expansion* fails closed. A missing target and a literal
+  branch name keep their documented fail-open: both are knowable in principle,
+  whereas an expansion's value does not exist yet at hook time. The
+  acknowledgement sigil deliberately does not clear this refusal either — it is
+  computed across the whole command, so one sigil on a loop would otherwise
+  license a round on every pull request the loop touched.

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -2274,6 +2274,69 @@ def _comment_target(argv: list[str]) -> tuple[str | None, str | None]:
     return pr_num, _comment_repo(argv) or url_repo
 
 
+# A shell expansion the hook can never resolve: PreToolUse sees the command
+# BEFORE the shell runs, so `$n`, `"$PR"`, `$(gh …)` and backticks are literal
+# text here, not a PR number.
+_UNEXPANDED_TARGET_RE = re.compile(r"\$\{?\w|\$\(|`")
+
+
+def _comment_target_unexpanded(argv: list[str]) -> str | None:
+    """The ``gh pr comment`` positional target when it is an UNEXPANDED shell
+    expansion rather than a resolvable PR reference.
+
+    Why this exists as a separate probe instead of widening ``_comment_target``:
+    that function's ``(None, …)`` result is overloaded. It means "no number" for
+    three different situations — no positional at all, a literal BRANCH name,
+    and an expansion — and only the third is unknowable in principle. The first
+    two keep their documented fail-open; a branch is resolvable by anyone who
+    cares to look it up, and a bare ``--body`` request has no target to count
+    against. An expansion is different in kind: no amount of parsing recovers
+    the number, because the value does not exist yet.
+
+    MEASURED 2026-09-08 — why this is a BLOCK and not an advisory: writing the
+    request as ``for n in 1625 1576 1609; do gh pr comment $n --body "@codex
+    review"; done`` posted round requests on two PRs already at or past
+    ``ESCALATION_ROUND_CAP`` with no ``# escalation-ack`` and no step-back
+    triage. The cap is itself a block, so an unknowable target leaves only
+    fail-open or fail-closed; an advisory would not have stopped it. Failing
+    closed here costs one rewrite with a literal number, which the refusal names.
+    """
+    try:
+        idx = argv.index("comment")
+    except ValueError:
+        return None
+    _VALUE_FLAGS = {"-b", "--body", "-F", "--body-file", "-R", "--repo"}
+    skip_next = False
+    for tok in argv[idx + 1 :]:
+        if skip_next:
+            skip_next = False
+            continue
+        if tok in _VALUE_FLAGS:
+            skip_next = True
+            continue
+        if tok.startswith("-"):
+            continue
+        # FIRST positional only — it is the target. A later one is body text,
+        # which may legitimately mention a price or a shell snippet.
+        return tok if _UNEXPANDED_TARGET_RE.search(tok) else None
+    return None
+
+
+def _unresolvable_target_advisory(token: str) -> str:
+    return (
+        f"BLOCKED: cannot tell which PR '{token}' is, so the Codex round cap "
+        "cannot be checked.\n"
+        "This hook runs BEFORE the shell expands anything, so a variable or "
+        "command substitution in the PR position is unreadable here — and an "
+        "unreadable target used to skip the cap entirely, which is how a loop "
+        "silently requested rounds past it.\n"
+        "Re-run with the PR number written literally, one command per PR:\n"
+        "  gh pr comment 1234 --body \"@codex review\"\n"
+        "If that PR is already at the cap you will get the step-back advisory, "
+        "which is the point."
+    )
+
+
 def _comment_repo(argv: list[str]) -> str | None:
     """Explicit ``--repo``/``-R`` value on a gh pr comment segment, if any.
 
@@ -2465,6 +2528,11 @@ def _check_codex_round_escalation(segs) -> tuple[bool, str]:
                 continue
             pr_num, repo = _comment_target(seg.argv)
             if not pr_num:
+                # An unexpanded expansion is unknowable here, so it fails CLOSED;
+                # a missing or branch target keeps its documented fail-open.
+                unresolvable = _comment_target_unexpanded(seg.argv)
+                if unresolvable:
+                    return True, _unresolvable_target_advisory(unresolvable)
                 continue
             # Count ALL Codex review rounds — including DISMISSED, which still
             # ran and consumed the budget (#1385 round-5). Freshness uses the

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -2233,6 +2233,119 @@ def _latest_codex_reviewed_sha(pr_num: str, repo: str | None = None) -> str | No
     return ids[-1] if ids else None
 
 
+# Value-taking flags whose SEPARATED value must not be read as the positional
+# target — a PR URL inside a `--body` text would otherwise redirect the gate to
+# an unrelated repo (#1385 round-5). Glued forms (`--body=…`, `-b…`, `-R…`,
+# `--repo=…`) are single `-`-prefixed tokens already skipped by the dash branch.
+# ONE copy, walked ONCE: the target scan and the identity check used to carry
+# their own copies of this loop, and two copies of a walk are two answers to
+# "which token is the target" waiting to disagree.
+_COMMENT_VALUE_FLAGS = frozenset({"-b", "--body", "-F", "--body-file", "-R", "--repo"})
+# The short letters of those value flags, for the GLUED spellings (`-bTEXT`,
+# `-F-`, `-Ro/r`, `-R=o/r`), which carry their value inside one token.
+_COMMENT_VALUE_SHORTS = frozenset("bFR")
+# gh pr comment's remaining flags — the ones that take NO value — from
+# `gh pr comment --help` (its own flags plus the inherited `--help`; `-R/--repo`
+# is inherited and lives in the value set above). This is a closed set for the
+# same reason the target forms are: see `_comment_positional`.
+_COMMENT_BOOL_FLAGS = frozenset(
+    {
+        "-e",
+        "--editor",
+        "-w",
+        "--web",
+        "--create-if-none",
+        "--delete-last",
+        "--edit-last",
+        "--yes",
+        "--help",
+    }
+)
+
+
+def _comment_positional(argv: list[str]) -> tuple[str | None, str | None]:
+    """``(target, unreadable_flag)`` for a ``gh pr comment`` segment's argv.
+
+    ``target`` is the FIRST positional token after ``comment`` — gh documents
+    exactly ONE (``[<number> | <url> | <branch>]``), so the first bare word IS
+    the whole target and a later one is not a second candidate to fall back on.
+    None means the request carries no positional at all
+    (``gh pr comment --body …``, which resolves the PR from the checked-out
+    branch); that keeps its documented fail-open, since there is no target to
+    count against.
+
+    ``unreadable_flag`` is a dash token this walk does not model, encountered
+    BEFORE any positional. It matters because an allowlist on the target's VALUE
+    is only as good as the walk that decides WHICH token the target is, and that
+    walk is the part that can still be a list of spellings. Its failure is
+    silent and in the wrong direction: gh's own parser bundles short flags, so
+    `-ewR o/r <target>` passes `o/r` to ``--repo`` and leaves the real target
+    two tokens later — while a walk that merely SKIPS the unrecognised `-ewR`
+    hands back `o/r`, an innocuous literal, and never looks at the target at
+    all. So an unmodelled flag makes the identity unreadable rather than being
+    skipped; the sibling precedent is `full_suite_guard`'s "an unlisted
+    value-flag falls back to a safe BLOCK, never a fail-open".
+
+    Measured 2026-09-08 against `gh pr comment --help`: no bundle containing
+    `-R` can both parse AND post (every companion short flag either conflicts
+    with the body source or swallows the rest of the bundle as its own value),
+    so this is a divergence with no reachable exploit TODAY — closed here
+    because the next gh flag is what makes it one, and because the walk should
+    not be the soft half of an allowlist design.
+    """
+    try:
+        idx = argv.index("comment")
+    except ValueError:
+        return None, None
+    skip_next = False
+    for tok in argv[idx + 1 :]:
+        if skip_next:
+            skip_next = False
+            continue
+        if tok in _COMMENT_VALUE_FLAGS:
+            skip_next = True
+            continue
+        # A bare `-` is not a flag: gh takes it as the positional, and so do we
+        # (it resolves to no pull request, which is gh's problem, not the cap's).
+        if tok.startswith("-") and tok != "-":
+            if tok == "--" or tok in _COMMENT_BOOL_FLAGS:
+                continue
+            # Glued value forms carry their own value in one token.
+            if tok.startswith("--") and "=" in tok:
+                continue
+            if not tok.startswith("--") and len(tok) > 2 and tok[1] in _COMMENT_VALUE_SHORTS:
+                continue
+            return None, tok
+        return tok, None
+    return None, None
+
+
+# EXTRACTION patterns — what a target MEANS. `_PR_URL_RE` keeps its original
+# shape (trailing context tolerated, e.g. a `#issuecomment-…` fragment) because
+# it reads the number and OWNER/REPO out of a URL.
+_PR_NUMBER_RE = re.compile(r"#?([0-9]+)\Z")
+_PR_URL_RE = re.compile(r"(?:[a-z]+://[^/\s]+/)?([^/\s]+/[^/\s]+)/pull/(\d+)\b")
+
+# ALLOWLIST patterns — what the gate accepts as unambiguously LITERAL. See
+# `_unresolvable_identity` for why these are allowlists and not screens.
+# A PR URL every character of which is inert to the shell. The trailing group
+# admits what a browser actually copies — `/files`, `/commits/<sha>`, a
+# `#issuecomment-…` deep link — none of which the shell acts on (`#` opens a
+# comment only at word start). It stops short of `?query`, because `?` is a
+# glob metacharacter and the shell WOULD act on it.
+_LITERAL_URL_RE = re.compile(
+    r"(?:[a-z]+://[A-Za-z0-9._-]+/)?[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/pull/[0-9]+"
+    r"(?:[/#][A-Za-z0-9._/#-]*)?\Z"
+)
+# A branch name in characters that are both legal in a git ref and inert to the
+# shell. `git check-ref-format` already excludes space ~ ^ : ? * [ and \; this
+# set additionally excludes every character the shell acts on — $ ` ! & ; | ( )
+# < > # { } ' " — so a token matching it expands to itself, quoted or not.
+_LITERAL_BRANCH_RE = re.compile(r"[A-Za-z0-9._/+,=%@-]+\Z")
+# `[HOST/]OWNER/REPO` in GitHub's own owner/repo character set.
+_LITERAL_REPO_RE = re.compile(r"[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+){1,2}\Z")
+
+
 def _comment_target(argv: list[str]) -> tuple[str | None, str | None]:
     """(pr_number, repo) from a ``gh pr comment`` segment's argv.
 
@@ -2241,108 +2354,123 @@ def _comment_target(argv: list[str]) -> tuple[str | None, str | None]:
     produce a wrong count and a FALSE block — Codex round-1 finding). An
     explicit ``--repo``/``-R`` flag wins over the URL-derived repo. A branch
     target (non-numeric, non-URL positional) yields (None, …) → fail-open.
+
+    Reads the FIRST positional only (``_comment_positional``), where this used
+    to scan every one of them for something number-shaped. gh accepts at most
+    one positional — `gh pr comment my-branch 1372` exits with "accepts at most
+    1 arg(s), received 2" — so a second bare word never named the PR that would
+    be commented on, and resolving one was reading an identity out of a command
+    that cannot run.
     """
+    tok, _ = _comment_positional(argv)
     pr_num: str | None = None
     url_repo: str | None = None
-    try:
-        idx = argv.index("comment")
-    except ValueError:
-        return None, None
-    # Value-taking flags whose SEPARATED value must not be read as the positional
-    # target — a PR URL inside a `--body` text would otherwise redirect the gate
-    # to an unrelated repo (#1385 round-5). Glued forms (`--body=…`, `-b…`,
-    # `-R…`, `--repo=…`) are single `-`-prefixed tokens already skipped below.
-    _VALUE_FLAGS = {"-b", "--body", "-F", "--body-file", "-R", "--repo"}
-    skip_next = False
-    for tok in argv[idx + 1 :]:
-        if skip_next:
-            skip_next = False
-            continue
-        if tok in _VALUE_FLAGS:
-            skip_next = True
-            continue
-        if tok.startswith("-"):
-            continue
-        if pr_num is None and tok.isdigit():
-            pr_num = tok
-        elif pr_num is None and tok.startswith("#") and tok[1:].isdigit():
-            pr_num = tok[1:]
-        elif pr_num is None:
-            url = re.match(r"(?:[a-z]+://[^/\s]+/)?([^/\s]+/[^/\s]+)/pull/(\d+)\b", tok)
+    if tok is not None:
+        num = _PR_NUMBER_RE.match(tok)
+        if num:
+            pr_num = num.group(1)
+        else:
+            url = _PR_URL_RE.match(tok)
             if url:
                 url_repo, pr_num = url.group(1), url.group(2)
     return pr_num, _comment_repo(argv) or url_repo
 
 
-# A shell expansion the hook can never resolve: PreToolUse sees the command
-# BEFORE the shell runs, so `$n`, `"$PR"`, `$(gh …)` and backticks are literal
-# text here, not a PR number.
-_UNEXPANDED_TARGET_RE = re.compile(r"\$\{?\w|\$\(|`")
+def _unresolvable_identity(argv: list[str]) -> str | None:
+    """The first identity-bearing value on a ``gh pr comment`` segment that is
+    not unambiguously literal, or None when the gate can read every identity it
+    needs.
 
+    THE CLASS, not a list of spellings. The cap counts rounds on ONE pull
+    request in ONE repository, so exactly two values decide what it counts: the
+    positional target, and the repository (an explicit ``--repo``/``-R``, or the
+    OWNER/REPO carried inside a URL target). A PreToolUse hook sees the command
+    BEFORE the shell runs, so a value carrying an expansion is not a value yet —
+    and screening for the expansions one can name is a losing shape: ``$n`` is
+    one spelling; ``$@``, ``$*``, ``${!v}``, ``${#v}``, ``$$``, ``$!``, ``$?``,
+    ``$#``, ``$-``, ``$(…)``, backticks and legacy ``$[…]`` are eleven more, and
+    the next round's finding is whichever one nobody enumerated.
 
-def _comment_target_unexpanded(argv: list[str]) -> str | None:
-    """The ``gh pr comment`` positional target when it is an UNEXPANDED shell
-    expansion rather than a resolvable PR reference.
+    So this ALLOWLISTS, per the house rule that a contract guard names what is
+    PERMITTED rather than what it imagined being attacked. gh documents the
+    target as ``[<number> | <url> | <branch>]`` and the repo as
+    ``[HOST/]OWNER/REPO``; each is accepted only when spelled in characters that
+    are inert to the shell, so it expands to itself. Every other spelling —
+    present and future — is refused by construction, without this function
+    knowing anything about shell expansion syntax.
 
-    Why this exists as a separate probe instead of widening ``_comment_target``:
-    that function's ``(None, …)`` result is overloaded. It means "no number" for
-    three different situations — no positional at all, a literal BRANCH name,
-    and an expansion — and only the third is unknowable in principle. The first
-    two keep their documented fail-open; a branch is resolvable by anyone who
-    cares to look it up, and a bare ``--body`` request has no target to count
-    against. An expansion is different in kind: no amount of parsing recovers
-    the number, because the value does not exist yet.
+    Two fail-opens are DELIBERATELY kept, both documented and both locked by
+    tests: a request with NO positional at all (nothing to count against), and a
+    literal branch target (resolvable by anyone who cares to look it up).
 
-    MEASURED 2026-09-08 — why this is a BLOCK and not an advisory: writing the
-    request as ``for n in 1625 1576 1609; do gh pr comment $n --body "@codex
-    review"; done`` posted round requests on two PRs already at or past
-    ``ESCALATION_ROUND_CAP`` with no ``# escalation-ack`` and no step-back
-    triage. The cap is itself a block, so an unknowable target leaves only
-    fail-open or fail-closed; an advisory would not have stopped it. Failing
-    closed here costs one rewrite with a literal number, which the refusal names.
+    The cost, stated plainly because it is real: ``shell_parse._argv`` runs
+    ``shlex.split`` first, so quoting is already gone by the time argv exists,
+    and a branch LITERALLY named ``$PR`` — legal per ``git check-ref-format``,
+    written ``'$PR'`` — is indistinguishable here from a live expansion and is
+    refused. Recovering it means deciding expandability from raw quoting, i.e.
+    hand-written shell-quote analysis inside the guard, whose failure direction
+    is a reopened bypass rather than a rewrite. One rewrite with a literal PR
+    number is the cheaper side of that trade, and the refusal names the remedy.
+
+    MEASURED 2026-09-08 — why a BLOCK and not an advisory: writing the request
+    as ``for n in 1625 1576 1609; do gh pr comment $n --body "@codex review";
+    done`` posted round requests on two PRs already at or past
+    ``ESCALATION_ROUND_CAP`` with no ``# escalation-ack`` and none of the
+    step-back triage the block exists to force. The cap is itself a block, so an
+    unreadable identity leaves only fail-open or fail-closed; an advisory would
+    not have stopped it.
     """
-    try:
-        idx = argv.index("comment")
-    except ValueError:
-        return None
-    _VALUE_FLAGS = {"-b", "--body", "-F", "--body-file", "-R", "--repo"}
-    skip_next = False
-    for tok in argv[idx + 1 :]:
-        if skip_next:
-            skip_next = False
-            continue
-        if tok in _VALUE_FLAGS:
-            skip_next = True
-            continue
-        if tok.startswith("-"):
-            continue
-        # FIRST positional only — it is the target. A later one is body text,
-        # which may legitimately mention a price or a shell snippet.
-        return tok if _UNEXPANDED_TARGET_RE.search(tok) else None
+    tok, unreadable_flag = _comment_positional(argv)
+    # A flag the walk does not model comes FIRST: until we know whether it eats
+    # the following word, we do not know which token the target is, so the
+    # target's own allowlist has nothing trustworthy to judge.
+    if unreadable_flag is not None:
+        return unreadable_flag
+    if tok is not None and not (
+        _PR_NUMBER_RE.match(tok) or _LITERAL_URL_RE.match(tok) or _LITERAL_BRANCH_RE.match(tok)
+    ):
+        return tok
+    # The repo is identity-bearing too, and is read on a path the target check
+    # cannot cover: with a LITERAL number and `--repo "$REPO"`, the number
+    # resolves, the query goes to the literal path `repos/$REPO/…`, the API
+    # errors, and the error fails OPEN — the cap skipped by a different door.
+    # Checked against the value AS WRITTEN, before the host reduction, so an
+    # expansion in the host position cannot be dropped on the way in.
+    repo = _comment_repo_value(argv)
+    if repo is None and tok is not None:
+        url = _PR_URL_RE.match(tok)
+        repo = url.group(1) if url else None
+    if repo is not None and not _LITERAL_REPO_RE.match(repo):
+        return repo
     return None
 
 
-def _unresolvable_target_advisory(token: str) -> str:
+def _unresolvable_identity_advisory(token: str) -> str:
     return (
-        f"BLOCKED: cannot tell which PR '{token}' is, so the Codex round cap "
-        "cannot be checked.\n"
-        "This hook runs BEFORE the shell expands anything, so a variable or "
-        "command substitution in the PR position is unreadable here — and an "
-        "unreadable target used to skip the cap entirely, which is how a loop "
-        "silently requested rounds past it.\n"
-        "Re-run with the PR number written literally, one command per PR:\n"
-        "  gh pr comment 1234 --body \"@codex review\"\n"
+        f"BLOCKED: '{token}' does not name a pull request this hook can read, so "
+        "the Codex round cap cannot be checked.\n"
+        "This hook runs BEFORE the shell expands anything, so the PR target and "
+        "the --repo value are readable only when they are written out. The gate "
+        "accepts what gh documents, spelled literally; anything else is refused "
+        "rather than counted against the wrong pull request, or against none.\n"
+        "Re-run with the identity written out — a number, #N or a PR URL, and "
+        "OWNER/REPO for the repo — one command per PR:\n"
+        '  gh pr comment 1234 --body "@codex review"\n'
         "If that PR is already at the cap you will get the step-back advisory, "
         "which is the point."
     )
 
 
-def _comment_repo(argv: list[str]) -> str | None:
-    """Explicit ``--repo``/``-R`` value on a gh pr comment segment, if any.
+def _comment_repo_value(argv: list[str]) -> str | None:
+    """The explicit ``--repo``/``-R`` value AS WRITTEN, or None if absent.
 
-    Handles separated (``--repo o/r`` / ``-R o/r``), ``--repo=o/r``, and glued
-    ``-Ro/r`` forms. A host-qualified ``HOST/OWNER/REPO`` is reduced to its
-    OWNER/REPO tail (the REST path shape this gate queries).
+    Handles separated (``--repo o/r`` / ``-R o/r``), ``--repo=o/r``, glued
+    ``-Ro/r`` and ``-R=o/r`` forms. The value is otherwise unnormalised — the
+    identity check needs it as the user typed it, host part included — with one
+    exception: an EMPTY value reads as absent. Both empty spellings are commands
+    gh rejects outright, and treating them alike keeps ``--repo=`` from being
+    refused with an empty-quoted token in the message while ``-R=`` (which no
+    branch below matches) reads as no flag at all.
     """
     val: str | None = None
     for i, tok in enumerate(argv):
@@ -2354,6 +2482,17 @@ def _comment_repo(argv: list[str]) -> str | None:
             val = tok[2:]
         elif tok.startswith("-R=") and len(tok) > 3:
             val = tok[3:]
+    return val or None
+
+
+def _comment_repo(argv: list[str]) -> str | None:
+    """Explicit ``--repo``/``-R`` value on a gh pr comment segment, if any.
+
+    A host-qualified ``HOST/OWNER/REPO`` is reduced to its OWNER/REPO tail (the
+    REST path shape this gate queries); see ``_comment_repo_value`` for the
+    flag forms and for the unreduced value.
+    """
+    val = _comment_repo_value(argv)
     if val and val.count("/") >= 2:
         val = "/".join(val.split("/")[-2:])
     return val
@@ -2475,8 +2614,13 @@ def _check_codex_round_escalation(segs) -> tuple[bool, str]:
         short-circuit could never see the count it needed to be bounded by.
       rounds >= FINAL_ROUND_CAP, no final-accept → BLOCK with the terminal (an
         escalation-ack here is deliberately not enough)
-      numberless/branch target (no PR number)     → that segment allows;
+      no positional / literal branch target       → that segment allows;
         SCANNING CONTINUES (an allowed segment must not shield a later one)
+      identity not written literally (target OR
+        repo)                                     → BLOCK. The one fail-CLOSED
+        leg, and the ack does not clear it: `acked` is command-wide, so one
+        sigil on a loop would license a round on every PR it touches. See
+        `_unresolvable_identity` for why the accepted forms are an ALLOWLIST
       gh/API/parse error (ids is None)            → that segment allows, scan on
       rounds < ESCALATION_ROUND_CAP               → that segment allows, scan on
       cap <= rounds < FINAL_ROUND_CAP, no ack    → BLOCK with the step-back order
@@ -2526,13 +2670,16 @@ def _check_codex_round_escalation(segs) -> tuple[bool, str]:
                 continue
             if not any("@codex review" in tok.lower() for tok in seg.argv):
                 continue
+            # BEFORE resolving the number, not after: a literal number with an
+            # unreadable `--repo` resolves fine and still counts the wrong repo,
+            # so a check gated on `not pr_num` would never see it.
+            unresolvable = _unresolvable_identity(seg.argv)
+            if unresolvable is not None:
+                return True, _unresolvable_identity_advisory(unresolvable)
             pr_num, repo = _comment_target(seg.argv)
             if not pr_num:
-                # An unexpanded expansion is unknowable here, so it fails CLOSED;
-                # a missing or branch target keeps its documented fail-open.
-                unresolvable = _comment_target_unexpanded(seg.argv)
-                if unresolvable:
-                    return True, _unresolvable_target_advisory(unresolvable)
+                # A missing positional or a literal branch target keeps its
+                # documented fail-open; every other spelling was refused above.
                 continue
             # Count ALL Codex review rounds — including DISMISSED, which still
             # ran and consumed the budget (#1385 round-5). Freshness uses the

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -2473,10 +2473,28 @@ def _comment_repo_value(argv: list[str]) -> str | None:
     branch below matches) reads as no flag at all.
     """
     val: str | None = None
+    skip_next = False
     for i, tok in enumerate(argv):
-        if tok in ("--repo", "-R") and i + 1 < len(argv):
-            val = argv[i + 1]
-        elif tok.startswith("--repo="):
+        # A value-taking flag's VALUE is not argv structure — it is text the
+        # caller wrote, and it must not be re-read as a flag. Without this,
+        # `--body "-Request @codex review"` matched the glued `-R<value>` branch
+        # below and the body was mistaken for a repository, blocking a valid
+        # request. `_comment_positional` already skips these via the same set;
+        # this function did not, and that divergence IS the parse-drift class
+        # tests/test_hooks/test_value_flag_consistency.py exists to prevent —
+        # the separated `-R` form is named in its docstring as the bypass that
+        # motivated it.
+        if skip_next:
+            skip_next = False
+            continue
+        if tok in _COMMENT_VALUE_FLAGS:
+            # --repo/-R are themselves value flags: read their value, then skip
+            # it so the same token cannot also be scanned as a flag.
+            if tok in ("--repo", "-R") and i + 1 < len(argv):
+                val = argv[i + 1]
+            skip_next = True
+            continue
+        if tok.startswith("--repo="):
             val = tok.split("=", 1)[1]
         elif tok.startswith("-R") and len(tok) > 2 and not tok.startswith("-R="):
             val = tok[2:]

--- a/tests/test_hooks/test_git_push_guard_escalation.py
+++ b/tests/test_hooks/test_git_push_guard_escalation.py
@@ -486,6 +486,35 @@ class TestEscalationGate:
         cmd = 'gh pr comment $n --body "@codex review"  # escalation-ack'
         assert _check(cmd)[0] is True
 
+    def test_body_starting_with_a_repo_flag_is_not_a_repo(self, monkeypatch):
+        """A body's TEXT must never be read as argv structure.
+
+        `--body "-Request ..."` matched the glued `-R<value>` branch, so the
+        body was mistaken for a repository and the identity check blocked a
+        valid request. `_comment_positional` already skipped value-flag values
+        via `_COMMENT_VALUE_FLAGS`; `_comment_repo_value` did not, and that
+        divergence is the exact parse-drift class
+        test_value_flag_consistency.py's docstring names as the bypass that
+        motivated it — same shape, opposite direction (false block, not a
+        bypass), because this gate fails closed."""
+        argv = ["gh", "pr", "comment", "1372", "--body", "-Request @codex review"]
+        assert _mod._comment_repo_value(argv) is None
+
+    def test_body_file_value_is_not_a_repo(self, monkeypatch):
+        argv = ["gh", "pr", "comment", "1372", "-F", "-Ro/rogue"]
+        assert _mod._comment_repo_value(argv) is None
+
+    def test_a_real_repo_flag_after_a_body_still_parses(self, monkeypatch):
+        """The skip must not swallow a genuine --repo that FOLLOWS a body."""
+        argv = ["gh", "pr", "comment", "1372", "--body", "-R fake", "--repo", "o/r"]
+        assert _mod._comment_repo_value(argv) == "o/r"
+
+    def test_body_with_repo_flag_does_not_block_a_valid_request(self, monkeypatch):
+        """End to end through the gate: below the cap this must ALLOW."""
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP - 1)))
+        cmd = 'gh pr comment 1372 --body "-Request @codex review"'
+        assert _check(cmd) == (False, "")
+
     def test_api_error_fails_open(self, monkeypatch):
         monkeypatch.delenv("_TEST_GH_CODEX_REVIEWS", raising=False)
 

--- a/tests/test_hooks/test_git_push_guard_escalation.py
+++ b/tests/test_hooks/test_git_push_guard_escalation.py
@@ -205,6 +205,62 @@ class TestEscalationGate:
         monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP)))
         assert _check('gh pr comment --body "@codex review"') == (False, "")
 
+    def test_variable_target_fails_closed(self, monkeypatch):
+        """A `$n` in the PR position is unknowable to a PreToolUse hook, so it
+        must REFUSE rather than skip. This is the 2026-09-08 bypass: the request
+        written in a `for` loop posted rounds on two PRs already at/past the cap
+        with no ack, because an unresolvable target silently fell through."""
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP)))
+        block, msg = _check('gh pr comment $n --body "@codex review"')
+        assert block is True
+        assert "$n" in msg
+
+    def test_variable_target_fails_closed_even_below_cap(self, monkeypatch):
+        """Below the cap too: the refusal is about being unable to COUNT, not
+        about the count. Allowing it under the cap would still be guessing."""
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(0)))
+        assert _check('gh pr comment $n --body "@codex review"')[0] is True
+
+    def test_expansion_forms_all_fail_closed(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP)))
+        for form in (
+            'gh pr comment "$PR" --body "@codex review"',
+            'gh pr comment ${PR} --body "@codex review"',
+            'gh pr comment $(cat pr.txt) --body "@codex review"',
+        ):
+            assert _check(form)[0] is True, form
+
+    def test_literal_branch_target_still_fails_open(self, monkeypatch):
+        """The documented fail-open for a BRANCH target is deliberate and stays:
+        it is resolvable in principle, unlike an expansion."""
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP)))
+        assert _check('gh pr comment my-branch --body "@codex review"') == (False, "")
+
+    def test_expansion_in_body_is_not_a_target(self, monkeypatch):
+        """Only the FIRST positional is the target. A `$` inside the body must
+        not be read as one, or ordinary review prose starts getting refused."""
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP - 1)))
+        assert _check('gh pr comment 42 --body "costs $5 per $unit"') == (False, "")
+
+    def test_variable_target_on_non_codex_comment_untouched(self, monkeypatch):
+        """The refusal is scoped to a round REQUEST. An ordinary comment with a
+        variable target is none of this gate's business."""
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP)))
+        assert _check('gh pr comment $n --body "nice"') == (False, "")
+
+    def test_ack_does_not_clear_an_unresolvable_target(self, monkeypatch):
+        """The ack must NOT rescue this one, and that is the whole design.
+
+        `acked` is computed command-wide, so a single sigil on
+        `for n in …; do gh pr comment $n …; done` would license a round on every
+        PR the loop touches — the unbounded version of the chaining the terminal
+        tier already spends a license to stop. An acknowledgement names a
+        conscious decision about ONE PR; when the PR is unknowable the sigil has
+        nothing to attach to, so it cannot be honoured."""
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP)))
+        cmd = 'gh pr comment $n --body "@codex review"  # escalation-ack'
+        assert _check(cmd)[0] is True
+
     def test_api_error_fails_open(self, monkeypatch):
         monkeypatch.delenv("_TEST_GH_CODEX_REVIEWS", raising=False)
 

--- a/tests/test_hooks/test_git_push_guard_escalation.py
+++ b/tests/test_hooks/test_git_push_guard_escalation.py
@@ -221,26 +221,251 @@ class TestEscalationGate:
         monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(0)))
         assert _check('gh pr comment $n --body "@codex review"')[0] is True
 
-    def test_expansion_forms_all_fail_closed(self, monkeypatch):
+    def test_every_parameter_form_in_the_target_fails_closed(self, monkeypatch):
+        """The CLASS, enumerated — and the enumeration is not the mechanism.
+
+        The gate ALLOWLISTS gh's documented target spellings (a number, #N, a
+        PR URL, a branch in shell-inert characters); everything else is refused
+        by construction. These forms are the ones a screen would have had to
+        list — `$@`/`$*` (a wrapper forwarding its argument), the indirect and
+        length forms, the special parameters, substitutions, legacy arithmetic —
+        and the point of the list is that a spelling NOT on it is refused too,
+        so a new one cannot become the next round's finding."""
+        # Counter at ZERO on purpose: at the cap a target that DID resolve would
+        # block on the step-back path and this would stay green for the wrong
+        # reason. Below the cap, only the identity refusal can block — and the
+        # message is asserted, so the two verdicts cannot be confused.
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(0)))
+        for target in (
+            "$n",
+            '"$PR"',
+            "${PR}",
+            "${PR:-9}",
+            "${!name}",  # indirect expansion
+            "${#name}",  # length
+            '"$@"',  # a wrapper forwarding its whole argument list
+            '"$*"',
+            "$$",  # pid
+            "$!",  # last background pid
+            "$?",  # last exit status
+            "$#",  # argument count
+            "$-",  # current option flags
+            "$(cat pr.txt)",
+            "`cat pr.txt`",
+            "$[1+1]",  # legacy arithmetic
+            "~/pr",  # tilde expansion
+            "pr-*",  # glob
+            "{1,2}",  # brace expansion
+        ):
+            cmd = f'gh pr comment {target} --body "@codex review"'
+            block, msg = _check(cmd)
+            assert block is True, cmd
+            assert "does not name a pull request" in msg, cmd
+
+    def test_an_unmodelled_flag_makes_the_target_unreadable(self, monkeypatch):
+        """The allowlist on the VALUE is only as good as the walk that decides
+        WHICH token the target is — and that walk must not be the soft half.
+
+        gh's parser bundles short flags, so `-ewR o/r <target>` is `-e -w -R o/r`
+        and the real target sits two tokens later. A walk that merely SKIPS the
+        unrecognised `-ewR` hands back `o/r` — an innocuous literal that passes
+        the allowlist — and never looks at the target. So an unmodelled dash
+        token seen before any positional makes the identity unreadable.
+
+        MEASURED 2026-09-08: no bundle containing `-R` can both parse AND post
+        (every companion short flag either conflicts with the body source or
+        swallows the rest of the bundle), so there is no reachable exploit with
+        today's gh — and 0 of 530 real round requests hit this leg. It is closed
+        because the next gh flag is what makes it reachable."""
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(0)))
+        block, msg = _check('gh pr comment -ewR o/r $PR --body "@codex review"')
+        assert block is True
+        assert "-ewR" in msg
+
+    def test_every_modelled_flag_spelling_still_resolves(self, monkeypatch):
+        """The other half of the flag walk: every spelling gh documents must
+        still reach the count. A closed set that refuses real flags would be a
+        fail-closed bug rather than a fix."""
         monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP)))
         for form in (
-            'gh pr comment "$PR" --body "@codex review"',
-            'gh pr comment ${PR} --body "@codex review"',
-            'gh pr comment $(cat pr.txt) --body "@codex review"',
+            'gh pr comment 1372 -b "@codex review"',
+            'gh pr comment 1372 -b"@codex review"',
+            'gh pr comment 1372 --body="@codex review"',
+            'gh pr comment --repo o/r 1372 --body "@codex review"',
+            'gh pr comment -F body.md 1372 --body "@codex review"',
+            'gh pr comment --edit-last 1372 --body "@codex review"',
+            'gh pr comment -e 1372 --body "@codex review"',
+            'gh pr comment -- 1372 --body "@codex review"',
+            'gh pr comment 1372 --body "@codex review" >/dev/null 2>&1',
         ):
-            assert _check(form)[0] is True, form
+            block, msg = _check(form)
+            assert block is True, form
+            assert "does not name a pull request" not in msg, form
+
+    def test_a_literal_url_with_a_path_or_fragment_is_not_refused(self, monkeypatch):
+        """What a browser actually copies must not be read as an expansion.
+
+        `/files`, `/commits/<sha>` and a `#issuecomment-…` deep link are all
+        shell-inert — `#` opens a comment only at word start — so they resolve
+        to their PR and reach the count. An expansion or a glob anywhere in the
+        same URL still refuses (`?` is a glob metacharacter, hence excluded)."""
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP)))
+        for form in (
+            "https://github.com/o/r/pull/7",
+            "https://github.com/o/r/pull/7/",
+            "https://github.com/o/r/pull/7/files",
+            "https://github.com/o/r/pull/7/commits/abc123",
+            "https://github.com/o/r/pull/7#issuecomment-123",
+        ):
+            block, msg = _check(f'gh pr comment {form} --body "@codex review"')
+            assert block is True, form  # the STEP-BACK block: it resolved
+            assert "does not name a pull request" not in msg, form
+        for form in (
+            '"https://github.com/$O/r/pull/7/files"',
+            '"https://github.com/o/r/pull/7?x=*"',
+        ):
+            block, msg = _check(f'gh pr comment {form} --body "@codex review"')
+            assert block is True, form
+            assert "does not name a pull request" in msg, form
+
+    def test_unreadable_repo_fails_closed_with_a_literal_pr_number(self, monkeypatch):
+        """The repo is identity-bearing too, and it is read on a path the target
+        check cannot cover.
+
+        With a literal number and `--repo "$REPO"` the number resolves, so a
+        check gated on "no PR number" never runs — and the count then queries
+        the literal path `repos/$REPO/…`, which errors, and the error fails
+        OPEN. Same class, different door."""
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(0)))
+        for form in (
+            'gh pr comment 1372 --repo "$REPO" --body "@codex review"',
+            'gh pr comment 1372 --repo=$REPO --body "@codex review"',
+            'gh pr comment 1372 -R "$REPO" --body "@codex review"',
+            'gh pr comment 1372 -R$REPO --body "@codex review"',
+            # The host segment is identity-bearing as well: checked as WRITTEN,
+            # before the HOST/OWNER/REPO reduction drops it.
+            'gh pr comment 1372 --repo "$H/o/r" --body "@codex review"',
+            # A URL target carries a repo — an expansion inside it is refused
+            # for the same reason an expanded --repo is.
+            'gh pr comment https://github.com/$O/r/pull/7 --body "@codex review"',
+        ):
+            block, msg = _check(form)
+            assert block is True, form
+            assert "does not name a pull request" in msg, form
+
+    def test_literal_repo_forms_still_resolve(self, monkeypatch):
+        """Guard against over-refusal: every literal repo spelling the gate has
+        always accepted must still reach the COUNT, not the identity refusal."""
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP)))
+        for form in (
+            'gh pr comment 1372 --repo o/r --body "@codex review"',
+            'gh pr comment 1372 --repo=o/r --body "@codex review"',
+            'gh pr comment 1372 -Ro/r --body "@codex review"',
+            'gh pr comment 1372 --repo ghe.example.com/o/r --body "@codex review"',
+            'gh pr comment 1372 --repo o.r_x/re-po --body "@codex review"',
+        ):
+            block, msg = _check(form)
+            assert block is True, form  # at cap — the STEP-BACK block, not identity
+            assert "does not name a pull request" not in msg, form
+            assert "escalation-ack" in msg, form
 
     def test_literal_branch_target_still_fails_open(self, monkeypatch):
         """The documented fail-open for a BRANCH target is deliberate and stays:
-        it is resolvable in principle, unlike an expansion."""
+        it is resolvable in principle, unlike an expansion. The allowlist admits
+        the characters real branch names are made of."""
         monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP)))
-        assert _check('gh pr comment my-branch --body "@codex review"') == (False, "")
+        for branch in ("my-branch", "fix/codex-round-target", "release_2.0", "user@host"):
+            cmd = f'gh pr comment {branch} --body "@codex review"'
+            assert _check(cmd) == (False, ""), cmd
+
+    def test_a_branch_named_like_an_expansion_is_refused(self, monkeypatch):
+        """The ACCEPTED cost of the allowlist, locked so it stays a decision.
+
+        `shell_parse._argv` runs `shlex.split` first, so quoting is gone before
+        argv exists: a branch literally named `$PR` (legal per
+        `git check-ref-format`) is indistinguishable here from a live expansion,
+        and is refused. Recovering it means deciding expandability from raw
+        quoting — hand-written shell-quote analysis inside the guard, whose
+        failure direction is a reopened bypass rather than a rewrite. The refusal
+        names the remedy, and it costs one command."""
+        # Counter at zero, message asserted — see the note in the enumeration
+        # test above: at the cap this would pass even if the target resolved.
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(0)))
+        for cmd in (
+            "gh pr comment '$PR' --body \"@codex review\"",
+            'gh pr comment \\$PR --body "@codex review"',
+            "gh pr comment '`release`' --body \"@codex review\"",
+        ):
+            block, msg = _check(cmd)
+            assert block is True, cmd
+            assert "does not name a pull request" in msg, cmd
+
+    def test_a_value_flag_value_is_never_read_as_the_target(self, monkeypatch):
+        """What `_COMMENT_VALUE_FLAGS` exists for (#1385 round-5): a PR URL
+        inside a `--body` must not redirect the gate to an unrelated repo.
+
+        The flag-FIRST shapes are the ones that exercise the skip — with the
+        positional written first the walk returns before it ever reaches the
+        flag, so those assertions pass whether the set is right or empty."""
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP)))
+        # The body's URL names another repo; the TARGET is the trailing 1372.
+        assert _mod._comment_target(
+            ["gh", "pr", "comment", "--body", "https://github.com/evil/repo/pull/9", "1372"]
+        ) == ("1372", None)
+        assert _mod._comment_target(
+            ["gh", "pr", "comment", "-b", "https://github.com/evil/repo/pull/9", "1372"]
+        ) == ("1372", None)
+        # End to end: a body-first request still resolves to its own PR.
+        block, msg = _check(
+            'gh pr comment --body "see https://github.com/evil/repo/pull/9 @codex review" 1372'
+        )
+        assert block is True
+        assert "does not name a pull request" not in msg
 
     def test_expansion_in_body_is_not_a_target(self, monkeypatch):
         """Only the FIRST positional is the target. A `$` inside the body must
-        not be read as one, or ordinary review prose starts getting refused."""
+        not be read as one, or ordinary review prose starts getting refused.
+
+        Every body here CARRIES the trigger phrase on purpose: without it the
+        gate skips the segment before it looks at anything, so the assertion
+        would hold whatever the target logic did. (A mutation run caught exactly
+        that — the earlier version of this test passed with `--body` deleted
+        from the value-flag set, because its bodies were never round requests.)"""
         monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP - 1)))
-        assert _check('gh pr comment 42 --body "costs $5 per $unit"') == (False, "")
+        assert _check('gh pr comment 42 --body "@codex review — costs $5 per $unit"') == (
+            False,
+            "",
+        )
+        assert _check('gh pr comment 42 -b "@codex review, $5"') == (False, "")
+        # Flag FIRST — this one needs the value-flag skip to reach the target.
+        assert _check('gh pr comment --body "@codex review — costs $5" 42') == (False, "")
+
+    def test_a_second_positional_no_longer_resolves(self, monkeypatch):
+        """`_comment_target` reads the FIRST positional only, where it used to
+        scan every one for something number-shaped.
+
+        `gh pr comment my-branch 1372` exits with "accepts at most 1 arg(s),
+        received 2", so the second word never named the PR that would be
+        commented on — resolving it read an identity out of a command that
+        cannot run. Recorded so the change is a decision, not a rediscovery."""
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP)))
+        assert _mod._comment_target(["gh", "pr", "comment", "my-branch", "1372"]) == (None, None)
+        assert _check('gh pr comment my-branch 1372 --body "@codex review"') == (False, "")
+
+    def test_an_empty_repo_value_reads_as_absent_in_both_spellings(self, monkeypatch):
+        """`--repo=` and `-R=` are both commands gh rejects, and they must be
+        treated alike: one used to refuse with an empty token in the message
+        while the other read as no flag at all."""
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP)))
+        assert _mod._comment_repo_value(["gh", "pr", "comment", "1372", "--repo="]) is None
+        assert _mod._comment_repo_value(["gh", "pr", "comment", "1372", "-R="]) is None
+        for form in (
+            'gh pr comment 1372 --repo= --body "@codex review"',
+            'gh pr comment 1372 -R= --body "@codex review"',
+        ):
+            block, msg = _check(form)
+            assert block is True, form
+            assert "does not name a pull request" not in msg, form
 
     def test_variable_target_on_non_codex_comment_untouched(self, monkeypatch):
         """The refusal is scoped to a round REQUEST. An ordinary comment with a


### PR DESCRIPTION
## What

A Codex round request is now refused unless the hook can read **which pull
request it names**, instead of silently skipping the round-escalation cap.

## Why

The cap counts a PR's existing Codex reviews and blocks a further round until a
conscious `# escalation-ack`. It resolves the PR from the command text — but a
`PreToolUse` hook receives that text *before* the shell expands anything, so any
identity it could not read simply skipped the cap.

**Measured**: writing the request as a `for` loop over PR numbers posted round
requests against two pull requests already at or past the cap, with no
acknowledgement and none of the step-back triage the block exists to force. The
same request written with a literal number was refused correctly — which is what
distinguished a parsing gap from a broken cap.

## Scope of the change

Two values decide what the cap counts, and both are now covered:

- the **positional target** (`[<number> | <url> | <branch>]`), and
- the **repository** — an explicit `--repo`/`-R`, or the owner/repo carried
  inside a URL target. With a literal number and an unreadable repo the count
  went to a nonexistent API path, errored, and the error failed open.

Each is accepted by an **allowlist** of what `gh pr comment --help` documents,
spelled in characters the shell does not act on, so a spelling nobody enumerated
is refused by construction rather than added to a list next time. The same
polarity now applies to the walk that decides *which* token the target is: a flag
outside gh's own documented set makes the identity unreadable rather than being
skipped, because gh's parser bundles short flags and a skipped bundle can leave
the real target two tokens away.

| identity | behaviour | why |
| --- | --- | --- |
| no positional at all | fail-open (unchanged) | nothing to count against; locked by `test_numberless_comment_fails_open` |
| a literal branch name | fail-open (unchanged) | resolvable by anyone who looks it up; locked by a test so a later tightening cannot turn it into a false block |
| anything else, in either value | **refuse** | the gate cannot tell which PR it would be counting |

## The acknowledgement deliberately does not clear it

`acked` is computed across the whole command, so one sigil on a loop would
license a round on every PR the loop touched: the unbounded form of the chaining
the terminal tier already spends a license to prevent. An acknowledgement names
a decision about one PR; with the PR unknowable it has nothing to attach to.

## Cost, measured

Over **530** distinct real round requests in this install's history, **47
(8.9%)** are refused — 32 on the target, 15 on the repo, 0 on the flag walk. In
that corpus every one of them is a request whose PR or repository the cap
genuinely could not read; the most common shape by far is a literal PR number
alongside `--repo "$SLUG"`, which now needs the slug written out (or dropped,
when running inside the repo). A PR URL keeps working exactly as a browser
copies it, `/files` and `#issuecomment-…` included.

The accepted loss: `shell_parse._argv` runs `shlex.split` first, so quoting is
gone before argv exists, and a branch *literally named* `$PR` — legal per
`git check-ref-format` — is indistinguishable here from a live expansion and is
refused. Recovering it means deciding expandability from raw quoting, i.e.
hand-written shell-quote analysis inside the guard, whose failure direction is a
reopened hole rather than a rewrite. That shape occurs 0 times in the 530.

## Evidence

- **Verify-RED, 11 mutations, 0 survivors**: one hash-gated baseline, a
  `compile()` postcondition and an anchor occurrence count on every mutation,
  restore verified by hash, and a run emitting no pytest result line aborts.
  Each mutation names the behaviour it should kill — the two documented
  fail-opens included, so the refusal is provably narrow rather than blanket.
  One mutation survived on first pairing and exposed a weak assertion of mine
  (a test body that never carried the trigger phrase, so the gate skipped the
  segment before reaching the logic under test); the test was rewritten.
- **Differential against a real shell**: 41 raw target spellings, each run
  through the guard *and* through `bash`, asserting that whenever the guard
  accepts a token as literal the value bash actually passes equals the token it
  read. 0 divergent accepts. 16 `--repo` spellings, same method, same result.
- **Acceptance**: the original defect replayed through the live hook entry
  blocks (exit 2); a fully literal request below the cap still passes (exit 0);
  at the cap a literal request gets the step-back advisory, not this one — the
  two verdicts stay distinguishable.

## Not claimed

This closes the identity-resolution class for the target and the repo. It says
nothing about the trigger itself: a body supplied by `--body-file` or on stdin
never reaches this gate, which remains a documented coverage limit.

E2E: none — a `PreToolUse` hook, exercised through its real entry point in the
evidence above; there is no post-merge runtime surface beyond the next session
picking up the hook.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for pull request comment commands.
  - Ambiguous, dynamically generated, or unsupported pull request targets are now rejected instead of being skipped.
  - Invalid repository values and unrecognized command options are handled more safely.
  - Additional positional arguments can no longer be misinterpreted as the pull request target.
  - Escalation acknowledgments no longer bypass validation when the target cannot be resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->