### PR TITLE
fix(ci): triage the litellm SSTI advisory the audit cannot reach

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,14 @@ jobs:
           #       CVE-2026-59821 — Guardrails create/update code-exec (proxy).
           #       CVE-2026-59822 — MCP Streamable-HTTP OAuth2 auth bypass (proxy MCP
           #         gateway; Genesis's own MCP servers are fastmcp, not litellm's).
+          #       CVE-2026-37004 — SSTI to OS command execution via the
+          #         dotprompt_content parameter of the /prompts/test endpoint, from
+          #         an unsandboxed jinja2.Environment. CVSS 9.8, and unreachable for
+          #         the same structural reason as the four above: the sink is
+          #         litellm/proxy/prompts/prompt_endpoints.py, served only by the
+          #         proxy. pip-audit names 1.83.7 as the fix, which is past the
+          #         1.82.x malware the pin exists to avoid — so the pin stays and
+          #         the reachability argument, not the version, is what holds here.
           #     grep-verified: only litellm.acompletion / completion_cost /
           #     model_cost + exception types are imported — no proxy surface.
           #   diskcache 5.6.3 (CVE-2025-69872) — pickle-by-default RCE, no fixed
@@ -95,6 +103,7 @@ jobs:
             --ignore-vuln CVE-2026-59822 \
             --ignore-vuln CVE-2025-69872 \
             --ignore-vuln PYSEC-2026-2475 \
+            --ignore-vuln CVE-2026-37004 \
             --ignore-vuln PYSEC-2026-2476
 
   leak-detector:

--- a/changelog.d/20260908225318-fixed-litellm-ssti-audit-triage.md
+++ b/changelog.d/20260908225318-fixed-litellm-ssti-audit-triage.md
@@ -1,0 +1,14 @@
+- **The dependency audit no longer fails on a litellm advisory Genesis cannot
+  reach.** `CVE-2026-37004` (CVSS 9.8) is server-side template injection through
+  the `dotprompt_content` parameter of the `/prompts/test` endpoint, from an
+  unsandboxed `jinja2.Environment`. The sink is
+  `litellm/proxy/prompts/prompt_endpoints.py` and it is served only by the proxy,
+  which Genesis never starts — the same structural reason the four `2026-11`
+  proxy advisories are already triaged. Verified rather than assumed: all five
+  `litellm` imports in the tree are the client library, and the tree contains no
+  reference to `litellm.proxy`, `proxy_server`, or that endpoint.
+
+  It is triaged rather than upgraded because pip-audit names 1.83.7 as the fix,
+  which is past the 1.82.x releases the pin exists to avoid. Here the
+  reachability argument is what holds, not the version — so the pin stays and the
+  advisory is recorded with its reasoning next to the four of its own class.


### PR DESCRIPTION
## What

Adds `CVE-2026-37004` to the `dependency-audit` triage list, with its reasoning
recorded beside the four advisories of the same class.

## Why the job is red

`dependency-audit` fails on main (run `34282971781`, head `1d45dd8ea`) — every
other job in that run, including `test`, passes. The audit reports:

```
litellm 1.78.7  CVE-2026-37004  fix: 1.83.7
Found 1 known vulnerability, ignored 15 in 1 package
```

Published 2026-08-27, so it is a new advisory rather than a regression in
anything we changed. It blocks every open PR, because PR CI runs the same job.

## Why it is not reachable

The advisory is SSTI to OS command execution via the `dotprompt_content`
parameter of the `/prompts/test` endpoint, through an unsandboxed
`jinja2.Environment`. The CVE record's own code reference names
`litellm/proxy/prompts/prompt_endpoints.py` — the sink lives in `litellm/proxy/`
and is served only when the proxy server runs.

Verified rather than assumed:

- All five `litellm` import sites in the tree are the client library
  (`routing/litellm_delegate.py`, `eval/runner.py`,
  `eval/reflection_golden_set.py`, `contribution/version_gate.py`).
- A repo-wide search for `litellm.proxy`, `proxy_server`, `litellm[proxy]` and
  the endpoint path returns **zero** hits across `src/`, `scripts/` and
  `pyproject.toml`.

Genesis does not ship, start, or expose the vulnerable component. This is the
same structural reason the four `2026-11` proxy advisories directly above it in
the ignore list are already triaged.

## Why triaged rather than upgraded

`pip-audit` names 1.83.7 as the fix. `pyproject.toml` pins `litellm==1.78.7`
specifically because 1.82.x contains malware — so the upgrade crosses that range,
and moves five minor versions on the library every routed model call goes
through. Taking a real regression risk on that path to remove a vulnerability
whose code we do not ship is the worse trade.

Whether the pin should move at all is genuine separate work and is filed as its
own issue rather than folded into a CI fix.

## Verification

Run locally with `pip-audit 2.10.1`, with a control:

| run | `litellm 1.78.7 CVE-2026-37004` row |
| --- | --- |
| without `--ignore-vuln CVE-2026-37004` | **present** |
| with it | **absent** |

The control flips, so the flag does the work. The local environment carries
packages CI does not, so only that row's presence or absence is relied on — not
the local exit code. `ci.yml` re-parsed with `yaml.safe_load` after the edit.

## What this does not do

It does not make Genesis safe against this CVE if anyone ever runs the litellm
proxy here — the whole argument is that nobody does. The rationale comment says
so explicitly, so a future reader adding a proxy surface has a string to grep.

E2E: confirm `dependency-audit` passes on main's next push run, and that a PR's
next CI run no longer fails that job.
