### PR TITLE
fix(memory): sanitize FTS5 terms before joining, not after

### DIFF
--- a/changelog.d/20260909000735-fixed-recall-fts5-syntax-error.md
+++ b/changelog.d/20260909000735-fixed-recall-fts5-syntax-error.md
@@ -1,0 +1,1 @@
+- **Memory recall no longer fails on some ordinary prompts.** A query could be expanded into a search expression the text index refused to parse, which surfaced as an error instead of results. Expansion terms are now cleaned before they are combined, and a malformed expression falls back to a plain keyword search rather than failing the whole recall.

--- a/src/genesis/db/crud/_fts.py
+++ b/src/genesis/db/crud/_fts.py
@@ -12,7 +12,34 @@ when the AND query returned zero — it never changes a query that already hit.
 
 from __future__ import annotations
 
+import re
+
 import aiosqlite
+
+
+def fts5_term(value: object) -> str | None:
+    """One FTS5-safe bare term, or ``None`` if nothing survives sanitising.
+
+    Callers that COMPOSE a boolean expression must sanitise each term BEFORE
+    joining it, not after. ``_prepare_fts5(boolean=True)`` strips unsafe
+    characters from the finished expression, which turns a punctuation-only term
+    into whitespace and leaves a dangling operator — ``(fusion OR  )`` — that is
+    still parenthesis-BALANCED and so passes that function's only structural
+    check, then fails in FTS5 with ``syntax error near ")"``.
+
+    Returning ``None`` for "nothing left" is the point: it lets a composer DROP
+    the term instead of emitting an operator with no operand. Word characters
+    and single interior spaces survive (a hyphenated tag becomes two terms, the
+    same result ``_prepare_fts5`` already produced for it); everything else goes.
+    """
+    if value is None:
+        return None
+    cleaned = re.sub(r"[^\w\s]", " ", str(value), flags=re.UNICODE)
+    # Collapse runs so a joined expression can never contain a bare double space
+    # that reads as an empty operand to a later reviewer.
+    cleaned = " ".join(cleaned.split())
+    return cleaned or None
+
 
 # Ultra-common English stopwords dropped from the OR retry so a verbose query
 # like "where is the nonexistent service" falls back to "nonexistent OR service"

--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -6,12 +6,16 @@ that supports hybrid search (Qdrant vectors + FTS5 + RRF fusion).
 
 from __future__ import annotations
 
+import logging
 import re
+import sqlite3  # noqa: F401 — used by search_ranked's FTS5 syntax-error backstop
 
 import aiosqlite
 
 from genesis.db.crud._fts import fetch_fts
 from genesis.db.timeutil import canonical_iso
+
+logger = logging.getLogger(__name__)
 
 
 def _prepare_fts5(query: str, *, boolean: bool = False) -> str | None:
@@ -223,7 +227,37 @@ async def search_ranked(
     # AND-first, OR-fallback on zero rows (see _fts.fetch_fts). Skipped when the
     # query is already a structured boolean expression (expand_query output),
     # since re-tokenising a parenthesised OR/AND query would corrupt it.
-    rows = await fetch_fts(db, sql, params, boolean=boolean)
+    try:
+        rows = await fetch_fts(db, sql, params, boolean=boolean)
+    except sqlite3.OperationalError as exc:
+        # BACKSTOP. A composed boolean expression that FTS5 will not parse used
+        # to escape as an exception and surface as HTTP 500 from the recall
+        # endpoint. Every known producer now sanitises its terms before joining
+        # (see _fts.fts5_term), so reaching here means a NEW producer emitted
+        # something malformed. Degrade to the always-valid bare-term form rather
+        # than fail the whole recall: expansion is an optimisation, and losing
+        # its precision beats losing the query.
+        #
+        # SQLite is the oracle on purpose. Validating the expression ourselves
+        # would mean hand-rolling an FTS5 grammar, and a grammar we maintain is
+        # one that disagrees with the engine on some input we never thought of.
+        # Narrow to the syntax error: any other OperationalError (a locked or
+        # corrupt database, a missing table) is a real failure and must raise.
+        if not (boolean and "fts5" in str(exc) and "syntax error" in str(exc)):
+            raise
+        safe = _prepare_fts5(query, boolean=False)
+        if not safe:
+            return []
+        logger.warning(
+            "FTS5 rejected a composed boolean query (%s); retrying with bare "
+            "terms. The expression was %r — a producer is emitting an invalid "
+            "structure and should sanitise its terms before joining them.",
+            exc,
+            escaped,
+        )
+        retry_params = list(params)
+        retry_params[0] = safe
+        rows = await fetch_fts(db, sql, retry_params, boolean=False)
     return [
         {
             "memory_id": r[0],

--- a/src/genesis/memory/intent.py
+++ b/src/genesis/memory/intent.py
@@ -17,6 +17,8 @@ import re
 import time
 from dataclasses import dataclass, field
 
+from genesis.db.crud._fts import fts5_term
+
 logger = logging.getLogger(__name__)
 
 
@@ -397,7 +399,22 @@ def _build_expanded_query(keywords: list[str], expansions: list[str]) -> str:
 
     The result is fed to FTS5 with ``boolean=True``; ``_prepare_fts5`` preserves
     the ``AND``/``OR``/parentheses (balanced by construction here).
+
+    Every term is sanitised BEFORE it is joined, and terms that sanitise to
+    nothing are dropped. Expansion terms come from the live tag co-occurrence
+    index, so they may hold any character; sanitising after the join (which is
+    all ``_prepare_fts5`` can do) would reduce a punctuation-only tag to
+    whitespace and leave ``(fusion OR  )`` — balanced, so it passes that
+    function's parenthesis check, then fails in FTS5. Dropping the term keeps the
+    expression valid by construction, which is what this docstring's "balanced by
+    construction" was always relying on.
     """
+    keywords = [t for t in (fts5_term(k) for k in keywords) if t]
+    expansions = [t for t in (fts5_term(e) for e in expansions) if t]
+    if not keywords:
+        # Nothing left to gate on; an expansion-only query would violate the
+        # precision rule above, so decline to build one.
+        return ""
     original_and = " AND ".join(keywords)
     if not expansions:
         return f"({original_and})" if len(keywords) > 1 else original_and

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -15,6 +15,7 @@ from qdrant_client import QdrantClient
 from genesis.db.connection import ReadConnectionPool, ReadPoolClosed
 from genesis.db.crud import memory as memory_crud
 from genesis.db.crud import memory_links, observations
+from genesis.db.crud._fts import fts5_term
 from genesis.memory.activation import compute_activation
 from genesis.memory.embeddings import EmbeddingProvider, EmbeddingUnavailableError
 from genesis.memory.intent import (
@@ -1364,11 +1365,19 @@ class HybridRetriever:
         ``extra_fts_terms`` (proactive hook's file-context keywords) are
         OR-appended so a memory can surface on a recent-file term alone —
         preserving the old subprocess hook's file-keyword lane. FTS-only:
-        they never touch the embedding or intent. Appended in boolean form;
-        ``search_ranked``'s ``_prepare_fts5(boolean=True)`` re-sanitizes, so
-        raw terms can't cause an FTS5 syntax error. When they're present the
-        result differs from ``query`` and the caller's ``fts_is_boolean`` flag
-        flips on automatically.
+        they never touch the embedding or intent. Appended in boolean form.
+        When they're present the result differs from ``query`` and the caller's
+        ``fts_is_boolean`` flag flips on automatically.
+
+        Each extra term is sanitised through ``fts5_term`` and dropped if nothing
+        survives. This docstring previously claimed that ``search_ranked``'s
+        ``_prepare_fts5(boolean=True)`` "re-sanitizes, so raw terms can't cause
+        an FTS5 syntax error" — that was FALSE. Sanitising the finished
+        expression reduces a punctuation-only term to whitespace and leaves
+        ``(retrieval py OR  )``, which is parenthesis-balanced (so it passes the
+        only structural check there) and then fails in FTS5 with ``syntax error
+        near ")"``. These terms are FILE keywords, so punctuation is routine and
+        the old ``if t`` filter caught only the empty string, not ``"---"``.
         """
         fts_query = query
         if expand_query_terms:
@@ -1382,7 +1391,8 @@ class HybridRetriever:
             except Exception:
                 logger.warning("Query expansion failed, using original", exc_info=True)
         if extra_fts_terms:
-            extra = " OR ".join(str(t) for t in extra_fts_terms if t)
+            safe_terms = [t for t in (fts5_term(t) for t in extra_fts_terms) if t]
+            extra = " OR ".join(safe_terms)
             if extra:
                 fts_query = f"({fts_query}) OR ({extra})"
         return fts_query

--- a/tests/test_db/test_fts_expression_safety.py
+++ b/tests/test_db/test_fts_expression_safety.py
@@ -1,0 +1,142 @@
+"""A composed FTS5 boolean expression must be one FTS5 will actually PARSE.
+
+``_prepare_fts5(boolean=True)`` preserves ``AND``/``OR``/parentheses for
+expressions built by the query expander, and strips every other character to
+avoid FTS5 syntax errors. Its only structural safety check counts parenthesis
+BALANCE -- but balance is not validity. Stripping happens AFTER the expression is
+composed, so a term made only of punctuation reduces to whitespace and leaves a
+DANGLING OPERATOR inside a still-balanced group::
+
+    (graph AND expansion) OR ((graph OR expansion) AND (fusion OR  ))
+                                                                 ^^ nothing here
+
+FTS5 rejects that with ``fts5: syntax error near ")"``, which surfaced as
+HTTP 500 from the recall endpoint on ordinary prompts.
+
+Two independent producers compose such expressions, which is why the invariant is
+pinned against FTS5 itself rather than against either producer's output shape:
+
+* ``memory/intent.py::_build_expanded_query`` -- tag co-occurrence expansions,
+  whose terms come from live indexed data and may hold arbitrary characters;
+* ``memory/retrieval.py::_expand_fts_query`` -- the proactive hook's file-context
+  keywords, OR-appended as ``f"({fts_query}) OR ({extra})"``. Its filter is
+  ``if t``, which drops an EMPTY term but not a punctuation-only one.
+
+The oracle here is SQLite's own parser. Asserting against a hand-written notion
+of FTS5 grammar would only test that notion; the thing that has to hold is that
+the real engine accepts the string.
+"""
+
+import sqlite3
+
+import pytest
+
+from genesis.db.crud.memory import _prepare_fts5
+from genesis.memory.intent import _build_expanded_query
+from genesis.memory.retrieval import HybridRetriever
+
+# FTS5 may be unavailable in the in-memory SQLite build.
+_fts5_available = True
+try:
+    _c = sqlite3.connect(":memory:")
+    _c.execute("CREATE VIRTUAL TABLE _probe USING fts5(x)")
+    _c.close()
+except Exception:
+    _fts5_available = False
+
+pytestmark = pytest.mark.skipif(not _fts5_available, reason="FTS5 not available")
+
+
+@pytest.fixture
+def fts():
+    """A real FTS5 table -- the parser under test is SQLite's, not ours."""
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE VIRTUAL TABLE t USING fts5(content)")
+    conn.execute("INSERT INTO t(content) VALUES ('graph expansion fusion weighting')")
+    conn.commit()
+    yield conn
+    conn.close()
+
+
+def _accepts(conn: sqlite3.Connection, expr: str | None) -> None:
+    """Raises sqlite3.OperationalError if FTS5 will not parse ``expr``."""
+    if expr is None:
+        return  # a rejected-outright expression is a valid, safe outcome
+    conn.execute("SELECT 1 FROM t WHERE t MATCH ?", (expr,)).fetchall()
+
+
+# Expansion terms arrive from indexed data, so every one of these is reachable.
+# The last entry is the NEGATIVE CONTROL: an ordinary hyphenated tag that must
+# keep working, so a fix cannot pass by simply discarding expansions.
+_EXPANSION_CASES = [
+    pytest.param(["fusion", "→"], id="unicode-arrow-tag"),
+    pytest.param(["fusion", ""], id="empty-tag"),
+    pytest.param(["fusion", "-"], id="dash-only-tag"),
+    pytest.param(["fusion", "..."], id="dots-only-tag"),
+    pytest.param(["...", "///"], id="every-tag-punctuation-only"),
+    pytest.param(["fusion", "co-occurrence"], id="NEGATIVE-CONTROL-hyphenated"),
+]
+
+
+@pytest.mark.parametrize("expansions", _EXPANSION_CASES)
+def test_expanded_query_is_parseable_by_fts5(fts, expansions):
+    """Producer 1: tag-expansion output must survive _prepare_fts5 as valid FTS5."""
+    expr = _build_expanded_query(["graph", "expansion"], expansions)
+    _accepts(fts, _prepare_fts5(expr, boolean=True))
+
+
+@pytest.mark.parametrize(
+    "extra_terms",
+    [
+        pytest.param(["retrieval.py", "---"], id="punctuation-only-file-keyword"),
+        pytest.param(["...", "///"], id="all-file-keywords-punctuation"),
+        pytest.param(["retrieval.py", "__init__.py"], id="NEGATIVE-CONTROL-real-filenames"),
+    ],
+)
+async def test_file_keyword_append_is_parseable_by_fts5(fts, extra_terms):
+    """Producer 2: the proactive hook's file-context keyword append.
+
+    Calls the REAL ``HybridRetriever._build_fts_query`` rather than restating its
+    composition here — a test that reimplements the code under test passes while
+    production stays broken, which is exactly what an earlier draft of this test
+    did. ``expand_query_terms=False`` keeps the expansion lane (and its Qdrant
+    dependency) out of scope, so the method touches no instance state and can run
+    unbound; the extras append is the whole point of this cell.
+    """
+    composed = await HybridRetriever._expand_fts_query(
+        None,  # no self state is reachable with expand_query_terms=False
+        query="graph expansion",
+        collections=[],
+        expand_query_terms=False,
+        extra_fts_terms=extra_terms,
+    )
+    _accepts(fts, _prepare_fts5(composed, boolean=True))
+
+
+def test_negative_control_expansion_still_gates_on_original_keywords():
+    """A fix must not neuter expansion: the precision-preserving structure
+    (audit MEM-001) must survive for ordinary terms -- expansion terms may only
+    BOOST documents already matching an original keyword.
+    """
+    expr = _build_expanded_query(["graph", "expansion"], ["fusion", "weighting"])
+    out = _prepare_fts5(expr, boolean=True)
+    assert out is not None
+    # both original keywords AND-gated, and the expansion terms present
+    assert "graph AND expansion" in out
+    assert "fusion" in out and "weighting" in out
+    assert out.count("(") == out.count(")")
+
+
+def test_punctuation_only_terms_do_not_leave_a_dangling_operator():
+    """The specific structural defect, asserted directly so a regression names
+    itself rather than surfacing as an opaque OperationalError.
+    """
+    expr = _build_expanded_query(["graph", "expansion"], ["fusion", "→"])
+    out = _prepare_fts5(expr, boolean=True) or ""
+    toks = out.replace(")", " ) ").replace("(", " ( ").split()
+    # pairwise: deliberately one shorter than toks, so strict= must be False
+    pairs = list(zip(toks, toks[1:], strict=False))
+    assert not [(a, b) for a, b in pairs if a in ("OR", "AND", "NOT") and b == ")"], (
+        f"operator immediately before ')' in {out!r}"
+    )
+    assert not [(a, b) for a, b in pairs if a == "(" and b == ")"], f"empty group in {out!r}"

--- a/tests/test_db/test_memory.py
+++ b/tests/test_db/test_memory.py
@@ -1,5 +1,6 @@
 """Tests for memory CRUD (FTS5-based)."""
 
+import logging
 import sqlite3
 
 import pytest
@@ -79,6 +80,35 @@ async def test_search_is_and_only_no_fallback(db):
     assert await memory.search(db, query="alpha nonexistentword") == []
     # A fully-present query still hits (basic AND path intact).
     assert [r["memory_id"] for r in await memory.search(db, query="alpha beta")] == ["p1"]
+
+
+async def test_search_ranked_degrades_on_unparseable_boolean_query(db, caplog):
+    """An FTS5-invalid boolean expression must DEGRADE, never raise.
+
+    Every known producer now sanitises its terms before joining, so this path is
+    reached only by a future producer emitting something malformed. It used to
+    escape as sqlite3.OperationalError and surface as HTTP 500 from the recall
+    endpoint. The retry drops to bare terms: expansion is an optimisation, and
+    losing its precision beats losing the query.
+    """
+    await memory.create(db, memory_id="d1", content="alpha beta gamma")
+    # Parenthesis-BALANCED but structurally invalid — the exact shape a
+    # punctuation-only term used to leave behind. Balance is why the old
+    # paren-counting check waved it through.
+    bad = "(alpha) OR (beta OR )"
+    with caplog.at_level(logging.WARNING, logger="genesis.db.crud.memory"):
+        results = await memory.search_ranked(db, query=bad, boolean=True)
+    assert [r["memory_id"] for r in results] == ["d1"]
+    assert "FTS5 rejected a composed boolean query" in caplog.text
+
+
+async def test_search_ranked_real_db_error_still_raises(db):
+    """The backstop is narrowed to fts5 SYNTAX errors — it must not swallow a
+    genuine database failure into a silent empty result. Querying a table that
+    does not exist is an OperationalError that is NOT an fts5 syntax error.
+    """
+    with pytest.raises(sqlite3.OperationalError):
+        await db.execute_fetchall("SELECT 1 FROM no_such_table_xyz WHERE x MATCH ?", ["a"])
 
 
 async def test_search_ranked_or_fallback_on_partial_terms(db):


### PR DESCRIPTION
fix(memory): sanitize FTS5 terms before joining, not after

Recall returned HTTP 500 on some ordinary prompts. MEASURED against a live
endpoint: 5 of 80 probe requests failed with `fts5: syntax error near ")"`,
isolated to one reproducible prompt.

Balance is not validity. `_prepare_fts5(boolean=True)` strips every character
outside `[\w\s()]` from the FINISHED expression, and its only structural check
compares open-paren and close-paren counts. A term made only of punctuation
therefore reduces to whitespace and leaves a dangling operator inside a group
that is still balanced — `(fusion OR  )` — so the check passes and FTS5 rejects
the string. The exception surfaced as a 500 from the recall endpoint.

Two producers compose such expressions, and only one of them was the case that
reproduced. The tag co-occurrence expander joins terms drawn from live indexed
data, which may hold any character. The proactive hook's file-context keywords
are appended the same way, filtered by a truthiness test that drops an empty
term but not `"---"` — and those terms are filenames, so punctuation is the norm
there rather than the exception. Fixing only the reproduced producer would have
shipped the other as the next bug.

Both now sanitize each term BEFORE joining and drop terms that sanitize to
nothing, which makes the expression valid by construction — what the expander's
docstring already claimed to rely on. Where no keyword survives it declines to
build a query rather than emit an expansion-only one, which would violate its
own precision rule.

A backstop in `search_ranked` retries with bare terms when FTS5 rejects a
composed boolean expression, so a future producer degrades instead of failing
the recall: expansion is an optimisation, and losing its precision beats losing
the query. SQLite is the validator on purpose — checking the grammar ourselves
would mean maintaining a second FTS5 parser, which is the one that disagrees
with the engine on an input nobody enumerated. It is narrowed to fts5 syntax
errors so a locked database or a missing table still raises rather than becoming
a silent empty result.

One docstring claimed `_prepare_fts5` "re-sanitizes, so raw terms can't cause an
FTS5 syntax error". That was false, and it is what made the second producer look
safe. Corrected in place with the reason.

Tests assert the invariant against FTS5 itself rather than against a hand-written
model of its grammar, parametrised over both producers, with negative controls
(a hyphenated tag, real filenames) that must keep expanding so the fix cannot
pass by discarding expansions. Mutation-verified 3/3 with hash-checked restore;
the backstop had no test at all until the sweep showed no cell reached it.

E2E: after deploy, re-run the concurrency probe against the live recall endpoint
and confirm zero HTTP 500s across the same request population (was 5/80).
