### PR TITLE
docs(skill): why a PR's CI can be missing, red, or lying

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -107,6 +107,32 @@ changes: verify the notification actually arrives. Ask: "If the system
 restarts right now, will this actually work?" If you can't answer yes
 with evidence, you're not done.
 
+**A check keyed on EXISTENCE can only confirm — it can never disconfirm.**
+Before trusting a verification, ask what it would do if the thing were absent,
+stale, or the wrong object. If the answer is "pass", it proved nothing. Three
+shapes of this, all measured in one session 2026-09-08:
+
+- **Waiting for a NEW artifact by testing that one exists.** A poll for "a
+  scheduled-review marker is present" passed instantly against a marker from six
+  days earlier. Key the wait on the artifact's IDENTITY — the head SHA it names —
+  not on its presence.
+- **Matching the first row instead of the right one.** "Is main green?" matched
+  the first `push` run for that SHA, which was the CodeQL workflow (success),
+  while the CI workflow for the same SHA had failed. Filter by the thing you
+  actually mean (`--workflow ci.yml`), and prefer reading the JOB you care about
+  over an aggregate conclusion.
+- **Counting from a listing sorted by the wrong key.** `gh pr list --state
+  merged --limit 40` sorts by CREATION, so PRs created earlier and merged today
+  fall outside the window and vanish; the count read low and looked plausible.
+  Use a query whose filter IS the property you are counting (`gh search prs
+  --merged-at`), per CLAUDE.md's truncated-listing rule.
+
+The failure is silent and self-confirming in all three: an under-read is
+indistinguishable from a clean result, so nothing prompts a second look. The
+tell is that the check passed FASTER or more easily than the work should have
+allowed — a poll that succeeds on the first attempt for something that takes
+40 seconds to produce has not observed that thing.
+
 **Verify in the REAL runtime context, not a shell proxy.** "Works when I
 run it" is not "works where it runs." Same code + same uid ≠ same context:
 a long-running systemd service (genesis-server, guardian) differs from your
@@ -2325,6 +2351,60 @@ The review-findings gate specifically:
    `ci: incomplete` and blocks (see the CI-gate bullet above) — the trap text
    stays because the DIAGNOSIS (check `mergeable` first) is still the fastest
    route to the cause.
+
+   Three corollaries, each measured 2026-09-08 and each costing a wrong diagnosis:
+
+   - **`UNKNOWN` suppresses it too, not just `CONFLICTING`.** GitHub recomputes
+     mergeability lazily, and EVERY merge to main invalidates it repo-wide — so
+     right after a merge batch the whole queue reads `UNKNOWN` and its CI looks
+     missing. That is also why a merge gate refuses with "mergeable status is
+     'UNKNOWN'": wait and re-read rather than concluding anything.
+   - **A PR opened against a NON-DEFAULT base never ran CI at all**, because
+     `ci.yml` filters `on: pull_request: branches: [main]` — the filter is on the
+     BASE. Retargeting it to main afterwards fires nothing: the default
+     `pull_request` types are opened/synchronize/reopened, and a base change is
+     none of them. This one does NOT self-heal and nothing will ever fire for it
+     again on its own; it needs a push. Stacked PRs land here by construction.
+   - **`workflow_dispatch` is not a workaround.** `gh workflow run ci.yml --ref
+     <branch>` runs to completion and never appears in the PR's
+     `statusCheckRollup`, so it cannot satisfy a gate that reads the rollup.
+
+9. **`gh run rerun` CANNOT clear a failure caused by a broken base.** It replays
+   the ORIGINAL merge commit rather than recomputing one against current main,
+   so re-running a PR whose base was broken faithfully reproduces the breakage.
+   MEASURED: a re-run started 15 minutes AFTER the fix merged still failed, and
+   `git merge-base --is-ancestor <fix-sha> refs/pull/<N>/merge` returned false —
+   the pull request's merge ref did not contain the fix. Only a push or
+   `gh pr update-branch <N>` recomputes it. Two consequences: do not "just
+   re-run" someone's stale red, and do not tell them it will clear — it will
+   not, and their next push clears it for free anyway.
+
+10. **`gh run view --log-failed` truncates and shows only PASSED lines.** On a
+    large suite it cuts around 44%, so a FAILING job reads as a clean log with
+    no failure in it — the most misleading possible output, because it looks
+    like an answer. It reported nothing useful on three separate attempts in one
+    session. To find what actually failed, reproduce locally against a clean
+    `origin/main` checkout (which is what identified it, twice), or fetch the
+    raw job log rather than the CLI's rendering.
+
+11. **Two individually-GREEN PRs can break main, and nothing warns you.** PR A
+    adds a repo-wide invariant test (one that ENUMERATES modules or consumers and
+    asserts a property); PR B adds a violation of it. Each is green against a
+    main that lacks the other, neither diff touches the other's files, so there
+    is no textual conflict, no reviewer signal, and both merge clean — then main
+    goes red, and because PR CI builds the merge commit it fails EVERY open PR on
+    a test unrelated to their changes. MEASURED 2026-09-08: a chokepoint test
+    requiring every consumer of the shared shell parser to use the checked entry
+    point, and a guard importing the unchecked one, merged an hour apart.
+    This is NOT the structural collision described under the architecture-session
+    rule — that one is main superseding a mechanism the PR uses, and it is
+    visible from the PR's own files. Here neither PR can see the other.
+    The detectable signature is a new ENUMERATING invariant test landing while
+    other PRs are in flight: when you merge one, re-run it against the other open
+    PRs' merge commits before merging them, not just against its own branch.
+    Sequencing follows from the same fact — batch merges rather than interleaving
+    them with active pushes, because each merge invalidates every other PR's
+    mergeability and manufactures the false "CI never ran" signal above.
 
 ## Reference Router
 

--- a/changelog.d/20260909004549-added-ci-diagnosis-and-existence-checks.md
+++ b/changelog.d/20260909004549-added-ci-diagnosis-and-existence-checks.md
@@ -1,0 +1,23 @@
+- **The development skill now covers why a PR's CI can be missing, red, or
+  lying.** Four diagnosis traps that each produced a wrong conclusion in one
+  session, added beside the existing conflict-suppression trap rather than
+  duplicating it: mergeability reading `UNKNOWN` after any merge (and so
+  suppressing CI queue-wide for a while); a PR opened against a non-default base
+  never running CI at all, because the workflow filters on the base and
+  retargeting emits no triggering event; `workflow_dispatch` completing without
+  ever appearing in the PR's check rollup; and `gh run rerun` replaying the
+  original merge commit, so it cannot clear a failure caused by a base that has
+  since been fixed.
+
+  Also recorded: `gh run view --log-failed` truncates on a large suite and shows
+  only PASSED lines, so a failing job reads as a clean log; and the class where
+  two individually-green pull requests break `main` together, because one adds a
+  repo-wide invariant test and the other adds a violation of it, with no textual
+  conflict between them and no signal until both have merged.
+
+- **A verification keyed on existence can only confirm.** The skill's
+  verify-outcomes guidance now names the shape directly: a check that would still
+  pass if the thing were absent, stale, or the wrong object has proven nothing.
+  Three worked examples, all of the same shape — waiting for a new artifact by
+  testing that any exists, matching the first row rather than the intended one,
+  and counting from a listing sorted by a key other than the one being counted.


### PR DESCRIPTION
## What

Five diagnosis findings from one reviewer session, each of which produced a
**wrong conclusion at the time**, written into the development skill where a
reader already looks.

## The non-duplication check, because it found something

These were approved on the condition that they do not already exist. A keyword
grep said they didn't — `rerun`, `workflow_dispatch`, `statusCheckRollup`,
`log-failed`, `update-branch` all returned zero across `SKILL.md` and all nine
`references/` files.

Reading found otherwise: bullet 8 of the pre-merge traps **already covers** a
CONFLICTING PR suppressing the CI suite, thoroughly. So that cause is not
re-added — the related causes hang off that bullet as corollaries instead of
becoming a rival section a reader would have to reconcile.

That is the same failure this diff documents (a check keyed on existence can
only confirm), caught on its own subject matter.

## Added

Corollaries to the existing bullet 8:

- Mergeability reads `UNKNOWN` after **any** merge, suppressing CI queue-wide.
- A PR opened against a **non-default base** never ran CI at all — `ci.yml`
  filters `on: pull_request: branches: [main]`, the filter is on the BASE, and
  retargeting emits none of the default trigger types. This one never
  self-heals.
- `workflow_dispatch` completes without appearing in the PR's check rollup.

New entries:

- **`gh run rerun` replays the ORIGINAL merge commit**, so it cannot clear a
  failure caused by a base that has since been fixed. Measured: a re-run started
  15 minutes after the fix merged still failed, and
  `git merge-base --is-ancestor <fix> refs/pull/<N>/merge` returned false.
- **`gh run view --log-failed` truncates** on a large suite and shows only
  PASSED lines, so a failing job reads as a clean log.
- **Two individually-green PRs can break `main` together** — one adds a
  repo-wide invariant test, the other adds a violation. No textual conflict, no
  signal until both merge, and then every open PR fails on an unrelated test.
  The entry states how this differs from the structural collision already
  documented, so the two are not conflated.

And in the verify-outcomes guidance: **a check keyed on existence can only
confirm.** If it would still pass when the thing is absent, stale, or the wrong
object, it proved nothing. Three worked examples, all from one session.

## Not claimed

That bullet 8's list is now complete, or that these are the only such traps. The
`--log-failed` truncation point is an observation from this repo's suite on this
date, not a documented constant — the text says "around" and the actionable half
is the remedy.

E2E: none — documentation only, no runtime surface.
