### PR TITLE
docs(skill): three ways a test can look rigorous and prove nothing

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -213,12 +213,20 @@ repo bounds exactly that at a few MiB (`autonomy/executor/deterministic.py`
 2026-09-04). Losing the tail of a log beats losing the process. The obligation
 there is not to keep the bytes, it is to be LOUD about the cut — say the output
 was bounded and roughly by how much, so nobody reads a clipped log as a
-complete one. That cited cap does NOT yet meet this bar: `_read_limited`
-returns only the retained bytes with no truncation flag, and its caller reports
-the retained length as the total — a 3 MiB stream reads as "2097152 bytes
-total". The cap is right; its silence is the improvable half, cited here as a
-counterexample to "never cut", not as a model of declaring. A silent lossy cap
-is still the defect; a declared one is a resource guard doing its job. This
+complete one. That cited cap has since been fixed AT THE READ and is no longer
+the silent-cut example it was: `_read_limited` drains the whole stream while
+retaining only `limit` bytes and returns `(retained, total_size)`, so the caller
+appends `... (truncated, N bytes total)` with N the TRUE drained total (PR
+#1796; verified in `autonomy/executor/deterministic.py` 2026-09-08).
+**It is still not a worked example of a loud cut, and the reason generalises:
+a declaration has to survive the CONSUMERS, not just be emitted.** That marker
+is appended at character 50,000 of the result field, and all six onward paths
+head-slice it at 200-2000 characters — including the one that feeds the next
+step's prompt — so the declaration is unreachable in every direction it
+travels, and the slice that removes it declares nothing itself (MEASURED
+2026-09-08). When you fix a silent cut, check the READERS of the field you just
+made honest; otherwise you have moved the silence one layer out. A silent lossy
+cap is still the defect; a declared one is a resource guard doing its job. This
 section is about the remaining case.
 
 **A handle that does not resolve is a separate defect, and do not conflate the
@@ -643,6 +651,60 @@ Adapted from superpowers `test-driven-development`, scoped to where it pays:
   succeeded. If the file no longer matches what the mutation wrote, PRESERVE it
   and report the conflict instead. The cleanest way to avoid the window entirely
   is to mutate inside an isolated worktree nobody else is editing.
+- **A RED for the WRONG REASON is not a verify-RED — read WHICH assertion
+  fired, never just that one did.** The six causes above all ask why an
+  expected RED came back GREEN. This is the mirror, and the dangerous half of
+  it passes review: the run failed, so the checklist is satisfied and the test
+  is trusted, but it failed on something other than the defect. **The tell is
+  any failure line you have not actually read.** Two shapes, and they cost
+  differently:
+  1. **The PRIMARY assertion fired, but on a condition the FIXTURE created**
+     rather than the defect — a leftover competing candidate, an unaged file,
+     stale state from setup. This one goes green on the fix, because the fix's
+     side effects remove the condition, so it passes review and pins nothing.
+     This is the expensive one.
+  2. **A guard-the-guard / precondition assertion fired FIRST**, which proves
+     the fixture never built the hazard at all. This one does NOT go green on
+     the fix — the fixture is unchanged, so it fails again and says so. It
+     costs a round, not a false green, and the guard is doing exactly its job
+     (see the vacuous-shapes bullet below, which prescribes adding one).
+     Repair the fixture and re-run before recording a RED.
+  MEASURED twice in one session on the same PR: a fileless-session test whose
+  file was not yet aged past the 60-second window, and a selection test with a
+  competing candidate still in the tree — each reported a textbook RED while
+  exercising nothing. Name the assertion that fired and confirm its message
+  describes the defect. A RED you have not read is a GREEN you have not earned.
+- **A fixture must create the shape its docstring claims — and the check is the
+  guard-the-guard assert, not a re-read.** This is the same obligation as the
+  vacuous-shapes bullet below; the addition here is WHERE the shape most often
+  goes wrong, which is a contract between two components. Two ways to break it,
+  both MEASURED in one session, and both PASS against the unfixed code — which
+  is the only way they are caught: a **hand-written intermediate** (the test fed
+  the consumer a value the real producer never emits, so the arity mismatch it
+  claimed to pin was never present) and an **inlined copy of the fix** (the test
+  ran the corrected logic as a snippet instead of invoking the real script, so
+  it graded its own copy and the shipped file never executed). If the defect
+  lives in the seam between a producer and a consumer, drive the REAL producer
+  into the REAL consumer; anything typed by hand in the middle is the bug's
+  hiding place, and anything inlined is a second copy of the code under test.
+- **Two reviewers pushing OPPOSITE values for the same constant, one review
+  pass apart, is a signal about the DEPENDENCY, not about the value.** (Review
+  passes here, not the cross-model *rounds* the escalation cap counts — see
+  that section for the reserved sense.) The instinct is to adjudicate: measure
+  the box, pick the winner, move on. That answers the pass and leaves the
+  mechanism, because both reviewers are usually right about the environment
+  each has in mind — which means the code depends on something that is not
+  invariant. MEASURED: one reviewer moved a parse to field `$4`, the next moved
+  it to `$5`, and both were correct, for different releases of the tool being
+  parsed. The value was never the defect; depending on column POSITION was.
+  Remove the dependency — match the field by what it IS, derive the index, or
+  read a named output format — which is usually cheaper than a third pass of
+  picking a number. **Scope: this applies where the constant names a POSITION
+  or a shape in something external** (a field index, a column offset, an offset
+  into a format you do not control). It does NOT apply to a threshold or a
+  timeout: there the disagreement is about which failure mode each reviewer has
+  in mind, and the Timeout Policy above governs — name the failure mode, and
+  the value follows from it.
 - **Vacuous-test shapes to check for by name** (a list of the common ones, not a
   definition). The most frequent in practice is the one that never ran at all: a
   test SKIPPED by a marker, or deselected by a `-k` filter or a wrong path, which

--- a/changelog.d/20260909010500-added-three-test-discipline-lessons.md
+++ b/changelog.d/20260909010500-added-three-test-discipline-lessons.md
@@ -1,0 +1,11 @@
+- **The development guide now names three ways a test can look rigorous and
+  prove nothing.** A test that fails before the fix is the standard evidence
+  that it caught something, but the failure has to come from the assertion that
+  describes the defect — when it comes from setup instead, what it proves is
+  that the test never built the situation it was written for. Related: a test
+  of the seam between two components has to run both of them, because a value
+  typed by hand in the middle is exactly where the defect hides, and a copy of
+  the fix pasted into the test grades the copy rather than the shipped code.
+  The guide also records that two reviewers pushing opposite values for the
+  same field position a review apart is a signal that the code depends on
+  something that is not fixed, not an invitation to pick a side.

--- a/changelog.d/20260909010501-changed-stale-bounded-read-example.md
+++ b/changelog.d/20260909010501-changed-stale-bounded-read-example.md
@@ -1,0 +1,7 @@
+- **Corrected a stale example about bounded output.** The development guide
+  cited the cap on a subprocess's captured output as an example of a size limit
+  that cuts without saying so. That limit now reports the true total alongside
+  the bytes it kept, so the guide no longer describes it as silent — but it
+  also records why the fix is not yet complete end to end: the notice is added
+  at the tail of a large field that every later reader trims well before it,
+  so a declaration still has to survive its consumers to count as one.


### PR DESCRIPTION
Three additions to the development skill's testing-discipline section, plus one correction to a stale claim already in it. All four come from defects measured while reviewing a single PR.

## What's added

**A RED for the wrong reason is not a verify-RED.** The section already lists six causes for an expected RED that came back GREEN. This is the mirror, and it passes review: the run failed, so the checklist is satisfied, but the failure came from somewhere other than the defect. Split into the two shapes because they cost differently — the primary assertion firing on a condition the *fixture* created goes green on the fix and pins nothing, while a guard-the-guard assertion firing first stays red after the fix and costs a round instead. Measured twice on one PR.

**A fixture must create the shape its docstring claims.** Deliberately framed as the same obligation the existing vacuous-shapes bullet already states, keeping that bullet's mechanical remedy (add the guard-the-guard assert) rather than introducing a second, softer one. What's new is where the shape most often goes wrong: the seam between two components. Two ways to break it, both of which pass against unfixed code — a hand-written intermediate the real producer never emits, and the fix inlined into the test so it grades its own copy.

**Two reviewers pushing opposite values for one constant is a signal about the dependency.** One review pass moved a parse to field `$4`, the next to `$5`; both were right, for different releases of the tool being parsed. The value was never the defect — depending on column position was. Scoped to constants that name a position in something external; thresholds and timeouts are explicitly excluded and routed to the existing Timeout Policy, which requires the opposite move.

## What's corrected

The section cited the cap on a subprocess's captured output as its example of a size limit that cuts silently. That is no longer true at the read — the cap now returns the true drained total and the caller declares it.

It is also not yet a worked example of a loud cut, and that turned out to be the more useful half. The notice is appended at character 50,000 of the result field, and all six onward consumers head-slice it at 200–2000 characters, including the one that feeds the next step's prompt. So the declaration is stripped in every direction it travels, and the slice that strips it declares nothing. The paragraph now carries that as the general rule: when you fix a silent cut, check the readers of the field you just made honest, or you have moved the silence one layer out.

## Review

One internal adversarial audit, which returned seven should-fix findings and no blocker. All seven applied, none accepted unfixed. The most useful was against the correction itself: the first draft promoted that cap to "the model", and the audit refuted it by reading the consumers rather than the function I had cited — which is why that lesson is now the substance of the paragraph rather than a footnote to it.

E2E: none — documentation only. The file is an instruction surface with no runtime path; the changelog fragments are validated by `assemble_changelog.py --check` (22 fragments, all valid).

Ledger: 49c493d8e6e1436cb8ee248a522c3a0b
Ledger: ac5e56f9a0064d72b0100fa57d5100ee