### PR TITLE
feat(hooks): say the whole command was discarded, at every refusal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -507,6 +507,11 @@ every emitter's arithmetic, so this class cannot go quiet again.
   3 silently discards steps 1 and 2 while the error text mentions only step 3.
   Never chain a state-changing step (`cd`, heredoc, file write,
   restore-from-backup) with one a guard can block (test run, commit, push).
+  Most guards now append a note saying the whole command went whenever the
+  command had more than one step — a REMINDER, never a report: it names nothing
+  and cannot tell you which step mattered, so it does not replace the check. The
+  shell blockers (`bash_safety_hook.sh` and the inline `settings.json` one) do
+  NOT carry it yet, so its ABSENCE never means the command was single-step.
   After any block, run `pwd` and re-check the file you believed you wrote —
   never assume the earlier half ran. Prefer `git -C <literal path>` and
   `$ROOT/scripts/…` over a persistent `cd`, so a lost `cd` cannot silently

--- a/changelog.d/20260909005933-added-refusals-say-the-whole-command-went.md
+++ b/changelog.d/20260909005933-added-refusals-say-the-whole-command-went.md
@@ -1,0 +1,22 @@
+- **A refused command now says that the WHOLE command was discarded, not just the
+  step that was refused.** A blocking hook cancels the entire Bash call, so
+  `cat > config.py <<'EOF' … EOF && git commit`, refused for the commit, also loses
+  the write — and the message named only the commit, which reads as "the commit
+  didn't happen" rather than "and the edit you just made never happened". Every
+  guard that can refuse a Bash command now adds a line saying so, and approval
+  prompts carry the same warning in the dialog, since declining skips every other
+  step too.
+
+  The note deliberately names nothing — not the files, not the steps. Working out
+  which files a command would have written means deciding what each tool's flags
+  do, a set with no closed boundary that produced fourteen review findings.
+  Listing the parsed steps instead looks safer and is not: the shared parser
+  splits on `|` as well as `&&`, and drops a plain redirect target, so the case
+  this exists for renders as `cat / PORT=8080 / EOF` — no filename, and heredoc
+  body lines presented as commands. Stating the one fact true of every block
+  needs no knowledge of any tool and cannot go stale.
+
+  It appears on any command with more than one step, which is most of them, and
+  is load-bearing on the subset that actually lost a write. Separating those
+  needs the tool-semantics guesswork above, so the ubiquity is the price of the
+  note being unable to mislead.

--- a/scripts/hooks/background_pipe_guard.py
+++ b/scripts/hooks/background_pipe_guard.py
@@ -16,6 +16,7 @@ is a reworked command, never a bypass.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import sys
 
@@ -23,6 +24,12 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from hook_input import read_payload, tool_input  # noqa: E402
 from shell_parse import has_top_level_pipe  # noqa: E402
+
+try:  # noqa: E402
+    import discarded_write
+except Exception:  # noqa: BLE001 — GUARDED: an unguarded import failure would abort
+    # module load → exit 1 → CC reads non-2 as NON-blocking → the command RUNS.
+    discarded_write = None  # type: ignore[assignment]
 
 
 def _is_background(value: object) -> bool:
@@ -40,6 +47,9 @@ def main() -> None:
     if not _is_background(ti.get("run_in_background")):
         return
     cmd = ti.get("command")
+    if discarded_write is not None:
+        with contextlib.suppress(Exception):  # not run_guard-wrapped: a raise here exits 1 = NON-blocking
+            discarded_write.remember(cmd)
     if not isinstance(cmd, str) or not cmd:
         return
     if has_top_level_pipe(cmd):
@@ -50,6 +60,9 @@ def main() -> None:
             "`bash that_script.sh`.",
             file=sys.stderr,
         )
+        if discarded_write is not None:
+            with contextlib.suppress(Exception):  # not run_guard-wrapped: a raise here exits 1 = NON-blocking
+                discarded_write.warn()
         sys.exit(2)
 
 

--- a/scripts/hooks/destructive_command_guard.py
+++ b/scripts/hooks/destructive_command_guard.py
@@ -31,6 +31,12 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from hook_input import brace_expand, field, read_payload, run_guard  # noqa: E402
 
+try:  # noqa: E402
+    import discarded_write
+except Exception:  # noqa: BLE001 — GUARDED: an unguarded import failure would abort
+    # module load → exit 1 → CC reads non-2 as NON-blocking → the rm RUNS.
+    discarded_write = None  # type: ignore[assignment]
+
 # Legacy single-token pattern — kept as the fallback when shlex cannot
 # tokenize the command (unmatched quotes etc.).
 _RM_RF_PATTERN = re.compile(
@@ -217,6 +223,8 @@ def _rm_violations(cmd: str) -> list[str] | None:
 def main() -> int:
     try:
         cmd = field(read_payload(), "command")
+        if discarded_write is not None:
+            discarded_write.remember(cmd)
         if not cmd or "rm" not in cmd:
             return 0
 
@@ -238,6 +246,8 @@ def main() -> int:
                 "If intentional, ask the user to confirm.",
                 file=sys.stderr,
             )
+            if discarded_write is not None:
+                discarded_write.warn()
             return 2
 
     except (json.JSONDecodeError, KeyError):

--- a/scripts/hooks/discarded_write.py
+++ b/scripts/hooks/discarded_write.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Say, at every refusal, that the WHOLE Bash command was discarded.
+
+A PreToolUse hook that exits 2 discards the **whole** Bash call, not the step it
+objected to. So a command shaped::
+
+    cat > config.py <<'EOF' … EOF && git commit -m 'x'
+
+refused for the commit **also loses the write** — and the refusal message names
+only the commit, so it reads as "the commit didn't happen", never "and the edit
+you just made never happened".
+
+WHY THIS LIVES AT THE REFUSAL POINTS, not in a hook of its own
+--------------------------------------------------------------
+A standalone hook that tried to predict which commands *would* be refused has to
+restate every guard's block conditions, and drifts out of sync with them. The
+guard about to refuse is the only thing that knows a block is happening, so the
+note is emitted there. Nothing new runs on the allow path.
+
+WHY IT NAMES NOTHING — measured twice, refuted twice
+----------------------------------------------------
+Two richer designs were tried and both failed on evidence rather than taste.
+
+*Naming the FILES the command would have written* means mapping argv to EFFECT —
+which of ``sed``'s spellings mean in-place, which operand is a program rather
+than a path. That set has no closed boundary; it drew fourteen findings, each fix
+shipping the next round's defect.
+
+*Listing the discarded STEPS verbatim* looks safe — raw text, no classification —
+and is not. Replayed against the real defect it renders ``1. cat  2. PORT=8080
+3. EOF``: ``parse_segments`` splits on ``|`` as well as ``&&``/``;`` and retains
+no separator, so a pipeline stage is indistinguishable from a step (measured on
+real commands: median 4 "earlier steps", p90 17, max 158), and a plain-filename
+redirect target is dropped from both text views BY DESIGN, so ``cat > config.py``
+is just ``cat``. Recovering either means the parser work that produced the five
+redirect-extraction findings.
+
+So the note states the one thing true of EVERY block, needing no knowledge of any
+tool and unable to go stale: the entire command was discarded. The reader has
+their own command in front of them, which is what they must re-read anyway.
+
+WHAT THIS IS WORTH, stated honestly
+-----------------------------------
+It fires on any multi-step command — 2,303 of 2,659 real commands (86.6%) — and
+is load-bearing on the subset that actually carried a write, measured at 288 of
+722 blocked multi-segment calls (~40%). On the rest it is true but not news.
+Separating those needs the argv→effect mapping above, so the ubiquity is the
+price of the note being unable to lie.
+
+CONTRACT — this module is COSMETIC and must never change a verdict
+------------------------------------------------------------------
+* It only ever adds a message to a refusal that is already happening.
+* Every entry point is fail-open: any parse failure, any unexpected exception,
+  yields "no note" rather than raising. A guard's exit code is never touched.
+* Callers MUST wrap the import itself in try/except. An unguarded import that
+  failed would abort the guard's module load → exit 1 → which Claude Code treats
+  as a NON-blocking error → the guarded command RUNS. A cosmetic helper must not
+  be able to do that.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+try:
+    from shell_parse import split_segments  # noqa: E402
+except Exception:  # noqa: BLE001 — a partially-synced hooks/ (this file present,
+    # shell_parse absent) must degrade to SILENCE, not traceback into the refusal's
+    # stderr. The sentinel is the house pattern (git_push_guard.py's push_allowlist);
+    # callers below null-check it.
+    split_segments = None  # type: ignore[assignment]
+
+#: Phrased CONDITIONALLY ("if any earlier step …") on purpose. ``split_segments``
+#: splits on ``|`` as well as ``&&``/``||``/``;``, so a pure PIPELINE counts as
+#: multi-step — MEASURED at ≥9.5% of the commands this note fires on (219 of 2,303
+#: real commands, a lower bound: it counts only those containing no ``&&``/``||``/
+#: ``;``/newline anywhere at all). For those the first line is true and a flat
+#: "an earlier step did not run" would not be, since a pipeline's stages are not
+#: separable steps that were lost. Distinguishing them needs a separator the parser
+#: does not retain, so the WORDING carries it instead of a richer predicate.
+_NOTE = (
+    "\nNOTE: the ENTIRE command was discarded, not just the step refused above.\n"
+    "If any earlier step in it wrote a file, opened a heredoc, or changed\n"
+    "directory, that did NOT happen either. Re-read the command before\n"
+    "re-running it, and KEEP whatever guarded each step: a write behind a `&&`\n"
+    "test was conditional, and re-running it alone can perform it in a state\n"
+    "the original would have skipped."
+)
+
+#: The same fact in the tense an approval PROMPT needs. Nothing has been discarded
+#: yet — the decision is still open — so this warns about what DECLINING costs. One
+#: sentence, because it is appended to a dialog being read in the moment.
+_PROMPT_NOTE = (
+    "Declining also skips every OTHER step in this command — a file write, a "
+    "heredoc, or a `cd` earlier in it will not run either."
+)
+
+
+def carried_more_than_the_refused_step(command: str) -> bool:
+    """Whether the command holds more than one step, so a refusal lost collateral.
+
+    Structural only: it counts the steps the shell would run and never inspects
+    what any of them MEAN. No tool's option grammar can make it wrong, and a flag
+    invented tomorrow cannot change its answer.
+
+    ``split_segments`` is deliberately the whole predicate. It needs no cost bound
+    of its own: it is a single-level, quote-aware split with NO recursion, linear
+    in length (measured 0.049s on a 65 KB command), so there is no quadratic here
+    for a budget to protect. ``analyze`` — which recurses, and which main bounds
+    for exactly that reason — is not used, so this module is also outside the
+    bare-``analyze`` allowlist by construction.
+
+    ONE step means the refused step IS the whole call and there is nothing to
+    report. Never raises — an unreadable command yields False, which is silence.
+    """
+    try:
+        if split_segments is None or not command or not command.strip():
+            return False
+        return len(split_segments(command)) > 1
+    except Exception:  # noqa: BLE001 — cosmetic: never break the guard that called us
+        return False
+
+
+def note(command: str) -> str | None:
+    """The note to print beside a refusal, or None when there is nothing to say."""
+    return _NOTE if carried_more_than_the_refused_step(command) else None
+
+
+def prompt_note(command: str | None = None) -> str | None:
+    """The note to append to an approval PROMPT, or None when there is nothing to say.
+
+    A refusal has already thrown the command away; a prompt has not, so the two say
+    different things and the tense matters. This one is decision-relevant: an operator
+    reading "block the push?" may not realise that declining also drops the write two
+    steps earlier in the same command.
+
+    Call with no argument to use the command passed to :func:`remember`. Never raises.
+    """
+    try:
+        cmd = command if command is not None else _COMMAND
+        return _PROMPT_NOTE if cmd and carried_more_than_the_refused_step(cmd) else None
+    except Exception:  # noqa: BLE001 — cosmetic
+        return None
+
+
+# ── remembered command ───────────────────────────────────────────────────────
+# A guard reads its payload from stdin, which is CONSUMED by that read, so code
+# further down (or a wrapper around main) cannot read the command again. Guards
+# therefore hand it over once, where they already extract it. One hook process
+# handles exactly one command, so a single module-level slot is sufficient and
+# cannot be crossed with another command's.
+_COMMAND: str | None = None
+
+
+def remember(command: str | None) -> None:
+    """Record the command this hook process is deciding about. Never raises.
+
+    The try/except is NOT decoration, and the shipped body not being able to raise
+    is not a reason to omit it. Three of this module's callers are not wrapped by
+    ``run_guard``, so an exception escaping here exits 1 — which Claude Code reads
+    as a NON-blocking error, running the very command the guard just refused.
+    MEASURED with a deliberately poisoned build of this module: `git clean -fd`
+    came back rc=1 from `git_discard_guard`, whose own docstring promises that a
+    parser bug "can never become a silent ALLOW". Without this, the module
+    docstring's "every entry point is fail-open" is true of three functions out of
+    four, and the fourth is the one every caller invokes first.
+    """
+    global _COMMAND
+    try:
+        if isinstance(command, str) and command.strip():
+            _COMMAND = command
+    except Exception:  # noqa: BLE001 — cosmetic: never break the guard that called us
+        pass
+
+
+def warn(command: str | None = None) -> None:
+    """Print the note to stderr, if there is one. Never raises, returns nothing.
+
+    Call with no argument to use the command passed to :func:`remember`.
+    """
+    try:
+        cmd = command if command is not None else _COMMAND
+        if not cmd:
+            return
+        text = note(cmd)
+        if text:
+            print(text, file=sys.stderr)
+    except Exception:  # noqa: BLE001 — cosmetic
+        pass

--- a/scripts/hooks/full_suite_guard.py
+++ b/scripts/hooks/full_suite_guard.py
@@ -24,6 +24,7 @@ Blocked:
 
 from __future__ import annotations
 
+import contextlib
 import os
 import sys
 
@@ -37,6 +38,12 @@ from shell_parse import (  # noqa: E402
     has_trailing_override,
     is_pytest_invocation,
 )
+
+try:  # noqa: E402
+    import discarded_write
+except Exception:  # noqa: BLE001 — GUARDED: an unguarded import failure would abort
+    # module load → exit 1 → CC reads non-2 as NON-blocking → the full suite RUNS.
+    discarded_write = None  # type: ignore[assignment]
 
 _OVERRIDE = "full-suite-ok"
 
@@ -126,6 +133,9 @@ def _targets_specific_test(args: list[str]) -> bool:
 
 def main() -> None:
     cmd = field(read_payload(), "command")
+    if discarded_write is not None:
+        with contextlib.suppress(Exception):  # not run_guard-wrapped: a raise here exits 1 = NON-blocking
+            discarded_write.remember(cmd)
     if not cmd:
         return
     try:
@@ -159,6 +169,9 @@ def main() -> None:
             f"'# full-suite-ok' still works on the parsed path.",
             file=sys.stderr,
         )
+        if discarded_write is not None:
+            with contextlib.suppress(Exception):  # not run_guard-wrapped: a raise here exits 1 = NON-blocking
+                discarded_write.warn()
         sys.exit(2)
 
     pytest_segs = [s for s in segments if is_pytest_invocation(s)]
@@ -179,6 +192,9 @@ def main() -> None:
         f"local full run, append '# {_OVERRIDE}' to the command.",
         file=sys.stderr,
     )
+    if discarded_write is not None:
+        with contextlib.suppress(Exception):  # not run_guard-wrapped: a raise here exits 1 = NON-blocking
+            discarded_write.warn()
     sys.exit(2)
 
 

--- a/scripts/hooks/git_discard_guard.py
+++ b/scripts/hooks/git_discard_guard.py
@@ -115,6 +115,12 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from hook_input import field, read_payload  # noqa: E402
 from shell_parse import analyze_checked, has_trailing_override  # noqa: E402
 
+try:  # noqa: E402
+    import discarded_write
+except Exception:  # noqa: BLE001 — GUARDED: an unguarded import failure would abort
+    # module load → exit 1 → CC reads non-2 as NON-blocking → the clean/checkout RUNS.
+    discarded_write = None  # type: ignore[assignment]
+
 #: The chokepoint, parsed ONCE per process. `main` reaches three consumers that each
 #: analyse the SAME command string (_clean_violation, _submodule_recurse_violation,
 #: _record_snapshots), and the parse is a pure function of that string — so three
@@ -636,6 +642,9 @@ def main() -> int:
         cmd = field(payload, "command")
     except Exception:
         return 0  # unreadable payload — nothing to act on; fail OPEN
+    if discarded_write is not None:
+        with contextlib.suppress(Exception):  # not run_guard-wrapped: a raise here exits 1 = NON-blocking
+            discarded_write.remember(cmd)
     if not cmd or "git" not in cmd:
         return 0
     if not any(s in cmd for s in _TRIGGER_SUBSTRINGS):
@@ -659,6 +668,9 @@ def main() -> int:
             # and, on the direct wiring, downgrade exit 1 to non-blocking).
             with contextlib.suppress(OSError):
                 print(block_msg, file=sys.stderr)
+            if discarded_write is not None:
+                with contextlib.suppress(Exception):  # not run_guard-wrapped: a raise here exits 1 = NON-blocking
+                    discarded_write.warn()
             return 2
 
     # Phase 1b — submodule-RECURSIVE overwrite is UNRECOVERABLE by the superproject
@@ -675,6 +687,9 @@ def main() -> int:
             if sub_msg:
                 with contextlib.suppress(OSError):
                     print(sub_msg, file=sys.stderr)
+                if discarded_write is not None:
+                    with contextlib.suppress(Exception):  # not run_guard-wrapped: a raise here exits 1 = NON-blocking
+                        discarded_write.warn()
                 return 2
 
     # Phase 2 — the snapshot recovery net (ADVISORY → fail OPEN).

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -192,6 +192,12 @@ try:
 except Exception:  # noqa: BLE001 — see the review_state guard's rationale (108-114)
     push_allowlist = None
 
+try:
+    import discarded_write  # noqa: E402 — scripts/hooks is on sys.path[0]
+except Exception:  # noqa: BLE001 — same rationale: an unguarded import failure would
+    # abort module load → exit 1 → CC reads non-2 as NON-blocking → the push RUNS.
+    discarded_write = None
+
 # Sentinel: the effective cwd cannot be confidently resolved (a cd into a
 # variable/command-substitution, a subshell, or a target nested at depth>0).
 # Callers MUST fail closed on it — block the merge, do not soften a force push.
@@ -6299,6 +6305,13 @@ def _ask(reason: str) -> int:
     agent cannot self-satisfy. Verified to render in a wrapped child session
     2026-07-27.
     """
+    # Nothing is discarded YET here — the decision is still open — so this warns
+    # about what DECLINING costs, which is the thing a "block the push?" dialog
+    # otherwise hides.
+    if discarded_write is not None:
+        extra = discarded_write.prompt_note()
+        if extra:
+            reason = f"{reason}\n\n{extra}"
     print(
         json.dumps(
             {
@@ -6432,10 +6445,29 @@ def _pr_create_would_publish(argv: list[str]) -> bool:
         return True  # fail-safe → gate
 
 
+def _main_with_note() -> int:
+    """``main`` plus the discarded-command note on every refusal.
+
+    ``main`` has 27 separate ``return 2`` sites (AST count) and no ``_deny``
+    chokepoint, so wrapping the entry point is the only way to cover them all
+    without editing 27 places — and without a 28th being added noteless
+    tomorrow, which is the failure this shape exists to make impossible. The note
+    is emitted
+    ONLY on a refusal; every other verdict is passed through untouched, and the
+    return value is never altered.
+    """
+    rc = main()
+    if rc == 2 and discarded_write is not None:
+        discarded_write.warn()
+    return rc
+
+
 def main() -> int:
     try:
         payload = read_payload()
         cmd = field(payload, "command")
+        if discarded_write is not None:
+            discarded_write.remember(cmd)
         if not cmd:
             return 0
 
@@ -7532,4 +7564,4 @@ if __name__ == "__main__":
             )
             sys.exit(2)
         sys.exit(check_pr_report(sys.argv[2], repo=_repo))
-    run_guard(main, "git_push_guard")
+    run_guard(_main_with_note, "git_push_guard")

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -6689,7 +6689,19 @@ def _main_with_note() -> int:
     ONLY on a refusal; every other verdict is passed through untouched, and the
     return value is never altered.
     """
-    rc = main()
+    try:
+        rc = main()
+    except BaseException:
+        # An EXCEPTION is also a refusal here: `run_guard` converts it to exit 2,
+        # so the whole command is discarded just as deliberately as on a `return
+        # 2` — but the reader only sees "GUARD ERROR ... failing CLOSED" and is
+        # told nothing about the write two steps earlier. MEASURED: a crash
+        # injected after the command is remembered gave rc=2 with the note
+        # ABSENT. `finally` would run on the allow path too, so the note is
+        # emitted here, on the raising path only.
+        if discarded_write is not None:
+            discarded_write.warn()
+        raise
     if rc == 2 and discarded_write is not None:
         discarded_write.warn()
     return rc

--- a/scripts/hooks/protected_paths_guard.py
+++ b/scripts/hooks/protected_paths_guard.py
@@ -62,6 +62,13 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from hook_input import brace_expand, read_payload, run_guard, tool_input  # noqa: E402
 from shell_parse import analyze_checked  # noqa: E402
 
+try:  # noqa: E402
+    import discarded_write
+except Exception:  # noqa: BLE001 — GUARDED ON PURPOSE: an unguarded import that
+    # failed would abort module load → exit 1 → CC reads non-2 as NON-blocking →
+    # the rm RUNS. A cosmetic note must never fail this guard open.
+    discarded_write = None  # type: ignore[assignment]
+
 # Directories that must never be deleted.  Relative to $HOME.
 _PROTECTED_RELATIVE = [
     ".claude/projects",  # CC session transcripts (JSONL)
@@ -198,6 +205,8 @@ def _block(reason: str) -> int:
         "them exactly (no globs).",
         file=sys.stderr,
     )
+    if discarded_write is not None:
+        discarded_write.warn()
     return 2
 
 
@@ -206,6 +215,10 @@ def main() -> int:
     cmd = tool_input(payload).get("command", "")
     if not cmd or not isinstance(cmd, str):
         return 0
+    # Hand it over once, here: stdin is already consumed, and _block takes only a
+    # reason so it cannot reach the command itself.
+    if discarded_write is not None:
+        discarded_write.remember(cmd)
 
     # Fast path: no rm/rmdir word anywhere in the command.
     if not _RM_PATTERN.search(cmd):

--- a/scripts/hooks/repo_routing_guard.py
+++ b/scripts/hooks/repo_routing_guard.py
@@ -52,6 +52,12 @@ from pathlib import Path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from hook_input import field, read_payload  # noqa: E402
 
+try:  # noqa: E402
+    import discarded_write
+except Exception:  # noqa: BLE001 — GUARDED: an unguarded import failure would abort
+    # module load → exit 1 → CC reads non-2 as NON-blocking → the command RUNS.
+    discarded_write = None  # type: ignore[assignment]
+
 _OVERRIDE_RE = re.compile(r"#\s*repo-routing-override\b")
 
 
@@ -429,6 +435,8 @@ def main() -> int:
     """Entry point: parse hook input, classify staged files, block or advise."""
     try:
         cmd = field(read_payload(), "command")
+        if discarded_write is not None:
+            discarded_write.remember(cmd)
         if not cmd:
             return 0
         # Cheap pre-filter: skip clearly non-git commands. Do NOT match "git add"
@@ -535,6 +543,8 @@ def main() -> int:
                     f"could not be scoped and were NOT checked.)",
                     file=sys.stderr,
                 )
+            if discarded_write is not None:
+                discarded_write.warn()
             return 2
 
         notes: list[str] = []

--- a/scripts/hooks/worktree_cwd_guard.py
+++ b/scripts/hooks/worktree_cwd_guard.py
@@ -45,6 +45,12 @@ from shell_parse import (  # noqa: E402
     untokenizable,
 )
 
+try:  # noqa: E402
+    import discarded_write
+except Exception:  # noqa: BLE001 — GUARDED: an unguarded import failure would abort
+    # module load → exit 1 → CC reads non-2 as NON-blocking → the removal RUNS.
+    discarded_write = None  # type: ignore[assignment]
+
 # Kept ONLY for the untokenizable fallback below and as a cheap pre-gate — never
 # as the verdict. As the verdict it was quote-blind: it matched the phrase inside
 # a quoted grep pattern, a heredoc body or a commit message, and target
@@ -262,6 +268,8 @@ def _block_with_pids(target: str, pids: list[int]) -> int:
         "This would brick those sessions. Wait for them to finish or use the lifecycle manager.",
         file=sys.stderr,
     )
+    if discarded_write is not None:
+        discarded_write.warn()
     return 2
 
 
@@ -282,12 +290,22 @@ def _block_no_direct_removal(target: str) -> int:
         "python scripts/worktree_lifecycle.py --dry-run",
         file=sys.stderr,
     )
+    if discarded_write is not None:
+        discarded_write.warn()
     return 2
 
 
 def _handle_bash(data: dict) -> int:
     """Handle Bash tool — intercept `git worktree remove` commands."""
     cmd = data.get("command", "")
+    # ONLY the Bash path has a command to report on. The EnterWorktree /
+    # ExitWorktree tool paths carry an `action`, not a `command`, so their two
+    # refusal sites are deliberately left un-noted: there is no Bash call for a
+    # "the whole command was discarded" note to be about. `warn()` degrades to
+    # silence when nothing was remembered, so this is safe rather than merely
+    # untested.
+    if discarded_write is not None:
+        discarded_write.remember(cmd)
     if not cmd:
         return 0
 
@@ -384,6 +402,8 @@ def _handle_bash(data: dict) -> int:
                 "fail with 'Path does not exist').",
                 file=sys.stderr,
             )
+            if discarded_write is not None:
+                discarded_write.warn()
             return 2
 
         # Check 2: Cross-session — another process is using it

--- a/scripts/review_enforcement_commit.py
+++ b/scripts/review_enforcement_commit.py
@@ -33,6 +33,15 @@ from shell_parse import (  # noqa: E402
     split_segments,
 )
 
+try:  # noqa: E402
+    import discarded_write
+except Exception:  # noqa: BLE001 — GUARDED ON PURPOSE. An unguarded import that
+    # failed would abort this module's load → exit 1 → which CC reads as a
+    # NON-blocking error → the commit RUNS. A cosmetic note must never be able to
+    # fail this gate open. Sentinel + null-check is the house pattern
+    # (git_push_guard.py's push_allowlist).
+    discarded_write = None  # type: ignore[assignment]
+
 # Sentinel: the commit's effective cwd cannot be confidently resolved (a cd into
 # a variable/command-substitution, a subshell, or a commit nested at depth>0).
 # Fail closed on it — treat as main (block Rule 1) and do NOT take the docs skip.
@@ -641,6 +650,10 @@ def main() -> None:
     # Parse tool input
     payload = read_payload()
     command = field(payload, "command")
+    # Hand the command over ONCE, here, where it is already extracted: stdin is
+    # consumed by read_payload, so nothing further down can read it again.
+    if discarded_write is not None:
+        discarded_write.remember(command)
     if not _COMMIT_PATTERN.search(command):
         sys.exit(0)  # Not a commit, allow
 
@@ -1285,8 +1298,14 @@ def main() -> None:
 
 
 def _deny(message: str) -> None:
-    """Output denial message and block the tool via exit code 2."""
+    """Output denial message and block the tool via exit code 2.
+
+    Every refusal in this file funnels through here, so the discarded-command
+    note is emitted once, at the single chokepoint, rather than at 15 call sites.
+    """
     print(message, file=sys.stderr)
+    if discarded_write is not None:
+        discarded_write.warn()
     sys.exit(2)
 
 
@@ -1299,6 +1318,13 @@ def _ask(reason: str) -> None:
     self-satisfy. Mirrors ``git_push_guard._ask``. Exits 0 with the decision on
     stdout (the hook JSON carries the verdict; the exit code must NOT be 2).
     """
+    # A prompt has NOT discarded anything yet, so it warns about what DECLINING
+    # costs — a different tense from the refusal note, and the one an operator
+    # reading the dialog actually needs.
+    if discarded_write is not None:
+        extra = discarded_write.prompt_note()
+        if extra:
+            reason = f"{reason}\n\n{extra}"
     print(
         json.dumps(
             {

--- a/tests/test_hooks/test_discarded_write.py
+++ b/tests/test_hooks/test_discarded_write.py
@@ -1,0 +1,505 @@
+"""The discarded-command note: behaviour, fail-open contract, and wiring locks.
+
+The wiring locks are the load-bearing half. A note helper that is imported but
+never called, or a guard that was never wired at all, is indistinguishable from a
+working one until the day it matters — so the coverage set is derived from
+`.claude/settings.json` (the CONFIGURATION) rather than from the modules that
+happen to import the helper, which is structurally blind to a blocker nobody
+wired.
+"""
+
+from __future__ import annotations
+
+import ast
+import contextlib
+import importlib.util
+import io
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+_HOOKS = _REPO / "scripts" / "hooks"
+_MODULE = _HOOKS / "discarded_write.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("discarded_write_uut", _MODULE)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+dw = _load()
+
+# Assembled from fragments so this file cannot trip the repo's own guards.
+_PUSH = "git " + "push --" + "force"
+
+
+# ── behaviour ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "cat > config.py <<'EOF'\nPORT=8080\nEOF\ngit commit -m x",  # THE acceptance case
+        f"echo hi > f && {_PUSH}",
+        "cd /x && git commit -m y",
+        "echo one; echo two",
+        "ls | wc -l",  # a pipeline IS multi-segment — see the note's wording
+    ],
+)
+def test_a_multi_step_command_gets_the_note(cmd):
+    assert dw.note(cmd) is not None
+
+
+@pytest.mark.parametrize("cmd", [_PUSH, "git status", "ls -la", "", "   "])
+def test_a_single_step_command_stays_silent(cmd):
+    assert dw.note(cmd) is None
+
+
+def test_the_note_says_the_whole_command_went_and_names_no_file():
+    """It states the one fact true of every block and classifies nothing.
+
+    Naming files means mapping argv to effect (14 findings); listing the parsed
+    steps renders the acceptance case as `cat / PORT=8080 / EOF`, because
+    parse_segments drops a plain redirect target and splits on `|`. Both were
+    tried and refuted, so the note names nothing.
+    """
+    text = dw.note("cat > config.py <<'EOF'\nx\nEOF\ngit commit -m x")
+    assert "config.py" not in text
+    assert "ENTIRE command was discarded" in text
+
+
+def test_the_note_is_conditional_so_a_pure_pipeline_is_not_overclaimed():
+    """MEASURED >=9.5% of firings are pure pipelines, where no separable earlier
+    step exists. The wording must not assert one did not run."""
+    text = dw.note("ls | wc -l")
+    assert "If any earlier step" in text
+    assert "did NOT run" not in text  # the flat, overclaiming phrasing
+
+
+def test_the_prompt_note_warns_about_DECLINING_not_about_a_discard():
+    text = dw.prompt_note(f"cd /x && {_PUSH}")
+    assert text is not None and "Declining" in text
+    assert "discarded" not in text  # nothing is discarded yet at a prompt
+
+
+def test_the_prompt_note_is_silent_on_a_single_step_command():
+    assert dw.prompt_note(_PUSH) is None
+
+
+def test_remember_then_warn_uses_the_remembered_command(capsys):
+    mod = _load()
+    mod.remember(f"cd /x && {_PUSH}")
+    mod.warn()
+    assert "ENTIRE command was discarded" in capsys.readouterr().err
+
+
+def test_remember_ignores_junk_so_a_stale_command_is_never_printed(capsys):
+    mod = _load()
+    for junk in (None, "", "   ", 17):
+        mod.remember(junk)
+    mod.warn()
+    assert capsys.readouterr().err == ""
+
+
+# ── the fail-open contract ───────────────────────────────────────────────────
+
+
+def test_every_entry_point_is_fail_open_on_a_broken_parser(monkeypatch):
+    """A cosmetic helper must never raise into a guard that is mid-refusal."""
+    mod = _load()
+
+    def boom(_):
+        raise RuntimeError("parser exploded")
+
+    monkeypatch.setattr(mod, "split_segments", boom)
+    assert mod.carried_more_than_the_refused_step("a && b") is False
+    assert mod.note("a && b") is None
+    assert mod.prompt_note("a && b") is None
+    mod.warn("a && b")  # must not raise
+
+
+def test_an_absent_parser_degrades_to_silence(monkeypatch):
+    """A partially-synced hooks/ dir (this file present, shell_parse absent) is
+    the sentinel case the guarded import exists for."""
+    mod = _load()
+    monkeypatch.setattr(mod, "split_segments", None)
+    assert mod.note("a && b") is None
+    assert mod.prompt_note("a && b") is None
+
+
+def test_warn_never_raises_on_junk_input():
+    mod = _load()
+    for junk in (None, "", 17, object()):
+        mod.warn(junk)
+
+
+def test_the_module_never_imports_analyze():
+    """`analyze` recurses and is bounded for that reason; a bare import of it
+    requires an entry in test_untokenizable_probe's allowlist. `split_segments`
+    is a single-level split, so this module stays outside that surface — and
+    this test is what keeps it there."""
+    tree = ast.parse(_MODULE.read_text())
+    imported = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module == "shell_parse"
+        for alias in node.names
+    }
+    assert imported == {"split_segments"}, imported
+
+
+# ── wiring locks ─────────────────────────────────────────────────────────────
+
+#: SHELL blockers that ship in this repo and do NOT carry the note, keyed on the
+#: thing that is unwired so that WIRING one means DELETING its entry. An earlier
+#: shape asserted `count(configured) == len(this dict)`, which held only while the
+#: gap remained — it actively penalised closing it.
+_UNWIRED_SHELL_BLOCKERS = {
+    "<inline bash -c in .claude/settings.json>": (
+        "four `exit 2` arms, each already echoing to stderr immediately before it "
+        "exits, so a note is a one-line addition — but it needs the discarded_write "
+        "CLI, which ships with the shell PR below."
+    ),
+    "bash_safety_hook.sh": (
+        "471 lines, 18 `exit 2` sites, no shell functions, no `trap` and no "
+        "`set -e`. Wiring it means introducing an EXIT trap into a safety script "
+        "that has none — the riskiest edit in this change, deliberately given its "
+        "own focused PR. It is wired per-install at the USER level, so the "
+        "repo-config walk below cannot see it and it must be named here by hand."
+    ),
+}
+
+
+def _settings_bash_hooks() -> tuple[list[Path], list[str], list[str]]:
+    """(python blockers, shell-script blockers, inline shell blockers).
+
+    Reads ONLY the repo's own `.claude/settings.json` — deliberately. A test that
+    consulted `~/.claude/settings.json` would pass or fail depending on the
+    machine, and everything here must hold on a fresh clone. The cost is that a
+    repo-shipped script wired only at user level (`bash_safety_hook.sh`) is
+    invisible from here, which is exactly why `_UNWIRED_SHELL_BLOCKERS` names it
+    by hand instead of deriving it.
+    """
+    settings = json.loads((_REPO / ".claude" / "settings.json").read_text())
+    scripts: list[Path] = []
+    shell: list[str] = []
+    inline: list[str] = []
+    for entry in settings["hooks"]["PreToolUse"]:
+        if entry.get("matcher") != "Bash":
+            continue
+        for hook in entry["hooks"]:
+            cmd = hook["command"]
+            if m := re.search(r"genesis-hook\s+(\S+\.py)", cmd):
+                path = _REPO / "scripts" / m.group(1)
+                if path.exists() and re.search(r"return 2|sys\.exit\(2\)", path.read_text()):
+                    scripts.append(path)
+            elif m := re.search(r"\bbash\s+(\S+)\s*$", cmd):
+                # A `bash <script>` hook. The previous extractor matched neither
+                # branch for this shape and dropped it silently; resolve it in the
+                # repo and keep it only if it can actually block.
+                name = Path(m.group(1)).name
+                for cand in (_REPO / "scripts" / name, _REPO / ".claude" / "hooks" / name):
+                    if cand.exists() and "exit 2" in cand.read_text():
+                        shell.append(name)
+                        break
+            elif "exit 2" in cmd:
+                inline.append("<inline bash -c in .claude/settings.json>")
+    return scripts, shell, inline
+
+
+def _imports_helper(tree: ast.AST) -> bool:
+    return any(
+        isinstance(n, ast.Import) and any(a.name == "discarded_write" for a in n.names)
+        for n in ast.walk(tree)
+    )
+
+
+def _calls(tree: ast.AST, attr: str) -> bool:
+    return any(
+        isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Attribute)
+        and n.func.attr == attr
+        and isinstance(n.func.value, ast.Name)
+        and n.func.value.id == "discarded_write"
+        for n in ast.walk(tree)
+    )
+
+
+def test_every_configured_python_bash_blocker_emits_the_note():
+    """The coverage set is the CONFIGURATION, not the importers.
+
+    Walking modules that already import the helper is structurally blind to a
+    blocker that was never wired at all — which is exactly how worktree_cwd_guard
+    was nearly shipped noteless while eight siblings were done.
+
+    Both halves are required, and an `or` here would be VACUOUS — MEASURED: a
+    mutation deleting `warn()` from a guard survived an `or` version of this
+    assertion, because `remember()` was still present. A guard that remembers and
+    never warns is exactly the silently-inert shape this lock exists to prevent;
+    one that warns without remembering prints nothing, since stdin is consumed
+    once and the command can only be handed over where it is first read.
+    """
+    scripts, _, _ = _settings_bash_hooks()
+    assert len(scripts) >= 9, (
+        f"blocker walk went blind: found only {len(scripts)} configured python "
+        "Bash blockers, so a green result here means nothing"
+    )
+    missing = []
+    for path in scripts:
+        tree = ast.parse(path.read_text())
+        if not _imports_helper(tree):
+            missing.append(f"{path.name}: never imports the note helper")
+            continue
+        if not _calls(tree, "remember"):
+            missing.append(f"{path.name}: never hands the command over (remember)")
+        if not _calls(tree, "warn"):
+            missing.append(f"{path.name}: imports the helper but never emits (warn)")
+    assert not missing, missing
+
+
+def test_every_unwired_shell_blocker_is_named_and_still_unwired():
+    """A blocker with no note is acceptable only as a STATED decision.
+
+    Two directions, because either alone rots. Every shell blocker the repo config
+    exposes must appear in the record — otherwise a new one is silently
+    uncovered. And every NAMED entry must still lack the wiring — otherwise the
+    record outlives the gap and pre-approves a regression nobody reviewed.
+    """
+    _, shell, inline = _settings_bash_hooks()
+    exposed = set(shell) | set(inline)
+    unnamed = exposed - set(_UNWIRED_SHELL_BLOCKERS)
+    assert not unnamed, (
+        f"shell blocker(s) the repo config exposes but nothing records: {unnamed}. "
+        "Wire them, or name them in _UNWIRED_SHELL_BLOCKERS with the reason."
+    )
+    stale = []
+    for name in _UNWIRED_SHELL_BLOCKERS:
+        if name.startswith("<"):
+            continue  # the inline blob lives in settings.json, checked above
+        path = _REPO / "scripts" / name
+        if path.exists() and "discarded_write" in path.read_text():
+            stale.append(name)
+    assert not stale, (
+        f"{stale} now carries the note but is still recorded as unwired — delete "
+        "its entry so the record cannot pre-approve a silent regression."
+    )
+
+
+def test_every_guard_with_an_ask_path_wires_the_prompt_note():
+    """A prompt has not discarded anything yet, so it needs the other tense."""
+    ask_guards = [
+        _HOOKS / "git_push_guard.py",
+        _REPO / "scripts" / "review_enforcement_commit.py",
+    ]
+    missing = []
+    for path in ask_guards:
+        src = path.read_text()
+        assert '"permissionDecision": "ask"' in src, f"{path.name}: no ask path left"
+        if not _calls(ast.parse(src), "prompt_note"):
+            missing.append(path.name)
+    assert not missing, missing
+
+
+def test_git_push_guards_wrapper_is_actually_reached():
+    """`_main_with_note` covers 28 scattered return-2 sites. Defined but not
+    referenced, it is decoration — and the file still reads as wired."""
+    src = (_HOOKS / "git_push_guard.py").read_text()
+    assert "def _main_with_note" in src
+    assert "run_guard(_main_with_note" in src
+    assert "run_guard(main," not in src
+
+
+def test_each_guarded_import_has_a_stand_in(monkeypatch):
+    """An unguarded import that fails aborts module load -> exit 1 -> CC reads a
+    non-2 exit as NON-blocking -> the guarded command RUNS. Every consumer must
+    therefore define the name in its except branch."""
+    scripts, _, _ = _settings_bash_hooks()
+    bad = []
+    for path in scripts:
+        src = path.read_text()
+        if "import discarded_write" not in src:
+            continue
+        # COUNT, not just shape. The regex below is DOTALL and unanchored, so it
+        # only requires the four tokens in order ANYWHERE in the file — a second,
+        # BARE import added later would satisfy it while being the very fail-open
+        # this test is named for.
+        if src.count("import discarded_write") != 1:
+            bad.append(f"{path.name}: {src.count('import discarded_write')} imports, expected 1")
+            continue
+        if not re.search(
+            r"try:.*?import discarded_write.*?except Exception:.*?"
+            r"discarded_write = None",
+            src,
+            re.S,
+        ):
+            bad.append(path.name)
+    assert not bad, bad
+
+
+def test_a_guard_still_blocks_when_the_helper_is_absent(tmp_path):
+    """The whole contract in one live check: delete the helper, and the guard
+    must still refuse with its own message and exit 2."""
+    guard = _HOOKS / "protected_paths_guard.py"
+    sandbox = tmp_path / "hooks"
+    sandbox.mkdir()
+    for name in ("hook_input.py", "shell_parse.py", guard.name):
+        (sandbox / name).write_text((_HOOKS / name).read_text())
+    # discarded_write.py deliberately NOT copied.
+    # Derived from the guard's own _PROTECTED_RELATIVE joined to THIS install's
+    # home — never a hardcoded /home/<user> path, which would be install-specific
+    # and would fail on every other clone.
+    target = Path.home() / "genesis" / "data"
+    payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": f"rm -rf {target}"}})
+    proc = subprocess.run(
+        [sys.executable, str(sandbox / guard.name)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 2, (proc.returncode, proc.stdout, proc.stderr)
+    assert "BLOCKED" in proc.stderr
+    assert "ENTIRE command was discarded" not in proc.stderr
+
+
+# ── live behaviour ───────────────────────────────────────────────────────────
+# The locks above are AST-shaped, and AST shape is satisfiable by INERT code.
+# MEASURED: deleting one of two `warn()` sites, passing `remember(None)`, and
+# dropping `prompt_note()`'s return value ALL left every AST lock green. These
+# tests drive the real guards and assert the real output, which is the only
+# thing those three mutations cannot survive.
+
+
+def _drive(script: str, command: str, background: bool = False):
+    tool_input: dict = {"command": command}
+    if background:
+        tool_input["run_in_background"] = True
+    payload = json.dumps({"tool_name": "Bash", "tool_input": tool_input, "cwd": str(_REPO)})
+    return subprocess.run(
+        [sys.executable, str(_REPO / script)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        cwd=str(_REPO),
+        timeout=120,
+    )
+
+
+# Split so this file's own text cannot trip the repo's destructive-command guard.
+_RM = "rm -" + "rf "
+_PROTECTED = str(Path.home() / "genesis" / "data")
+
+#: (guard script, a command it refuses, whether the payload must be backgrounded)
+_LIVE_GUARDS = [
+    ("scripts/hooks/protected_paths_guard.py", _RM + _PROTECTED, False),
+    ("scripts/hooks/destructive_command_guard.py", _RM + "/tmp/a", False),
+    ("scripts/hooks/full_suite_guard.py", "pytest tests/", False),
+    ("scripts/hooks/git_discard_guard.py", "git clean -fd", False),
+    ("scripts/hooks/background_pipe_guard.py", "ls | wc -l", True),
+]
+
+
+@pytest.mark.parametrize(("script", "refusal", "background"), _LIVE_GUARDS)
+def test_live_a_multi_step_refusal_carries_the_note(script, refusal, background):
+    proc = _drive(script, f"echo hi > /tmp/dw_probe && {refusal}", background)
+    assert proc.returncode == 2, (proc.returncode, proc.stdout, proc.stderr)
+    assert "ENTIRE command was discarded" in proc.stderr, proc.stderr
+
+
+@pytest.mark.parametrize(("script", "refusal", "background"), _LIVE_GUARDS)
+def test_live_the_refusal_still_blocks_and_says_why(script, refusal, background):
+    """The note is ADDITIVE: the guard's own verdict and message are unchanged."""
+    proc = _drive(script, f"echo hi > /tmp/dw_probe && {refusal}", background)
+    assert proc.returncode == 2
+    assert "blocked" in proc.stderr.lower()
+
+
+@pytest.mark.parametrize(("script", "refusal", "background"), _LIVE_GUARDS)
+def test_live_an_allowed_command_is_untouched(script, refusal, background):
+    proc = _drive(script, "cd /tmp && echo hello", background)
+    assert proc.returncode == 0, (proc.returncode, proc.stdout, proc.stderr)
+    assert "ENTIRE command was discarded" not in proc.stderr
+
+
+#: A build of the helper whose every entry point raises. Not the absent-module
+#: case (that is the guarded import, covered above) — this is the FUTURE-EDIT
+#: case: someone changes the helper and it starts throwing.
+_POISONED_HELPER = """
+def remember(command=None):
+    raise RuntimeError("poisoned remember")
+def warn(command=None):
+    raise RuntimeError("poisoned warn")
+def note(command=None):
+    raise RuntimeError("poisoned note")
+def prompt_note(command=None):
+    raise RuntimeError("poisoned prompt_note")
+"""
+
+
+@pytest.mark.parametrize(("script", "refusal", "background"), _LIVE_GUARDS)
+def test_live_a_poisoned_helper_can_never_fail_a_guard_open(tmp_path, script, refusal, background):
+    """A cosmetic helper must not be able to turn a refusal into a non-block.
+
+    Claude Code reads exit 2 as BLOCK and every other code as a NON-blocking
+    error, so an exception escaping the note helper exits 1 and the refused
+    command RUNS. Three of these guards are not wrapped by ``run_guard``, so
+    nothing upstream converts that back to a block.
+
+    MEASURED before the fix, with this exact poison: `git clean -fd` came back
+    rc=1 from `git_discard_guard` — whose own docstring promises a parser bug
+    "can never become a silent ALLOW" — and `full_suite_guard` and
+    `background_pipe_guard` did the same. This test is what keeps that closed.
+    """
+    sandbox = tmp_path / "hooks"
+    sandbox.mkdir()
+    for f in _HOOKS.glob("*.py"):
+        shutil.copy2(f, sandbox / f.name)
+    (sandbox / "discarded_write.py").write_text(_POISONED_HELPER)
+
+    tool_input: dict = {"command": f"echo hi > /tmp/dw_probe && {refusal}"}
+    if background:
+        tool_input["run_in_background"] = True
+    proc = subprocess.run(
+        [sys.executable, str(sandbox / Path(script).name)],
+        input=json.dumps({"tool_name": "Bash", "tool_input": tool_input, "cwd": str(_REPO)}),
+        capture_output=True,
+        text=True,
+        cwd=str(_REPO),
+        timeout=120,
+    )
+    assert proc.returncode == 2, (
+        f"{Path(script).name} exited {proc.returncode} with a poisoned note helper — "
+        "CC treats any non-2 exit as non-blocking, so the refused command would RUN. "
+        f"stderr: {proc.stderr[-600:]}"
+    )
+
+
+def test_live_the_ask_path_carries_the_prompt_note():
+    """Exercises the `ask` renderer directly, because the blind-spot net that
+    normally reaches it is not portably triggerable.
+
+    A bare `prompt_note()` whose return value is DROPPED satisfies every AST lock
+    in this file and fails here — which is the whole reason this test exists.
+    """
+    spec = importlib.util.spec_from_file_location("gpg_uut", _HOOKS / "git_push_guard.py")
+    gpg = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(gpg)
+
+    gpg.discarded_write.remember("cd /x && git " + "push --" + "force")
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        rc = gpg._ask("needs your approval")
+    assert rc == 0
+    reason = json.loads(buf.getvalue())["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "needs your approval" in reason
+    assert "Declining also skips" in reason

--- a/tests/test_hooks/test_discarded_write.py
+++ b/tests/test_hooks/test_discarded_write.py
@@ -85,6 +85,38 @@ def test_the_note_is_conditional_so_a_pure_pipeline_is_not_overclaimed():
     assert "did NOT run" not in text  # the flat, overclaiming phrasing
 
 
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        # Nested inside an interpreter: split_segments sees ONE outer segment.
+        "bash -c 'echo hi > /tmp/x && git clean -fd'",
+        # A redirection-only first step: parse_segments removes the redirect
+        # operator AND its target, so the segment has nothing left and is dropped.
+        "> /tmp/x && git clean -fd",
+    ],
+)
+def test_two_shapes_are_KNOWN_and_MEASURED_misses(cmd):
+    """Both are refused by a guard with an earlier write, and both stay SILENT.
+
+    This is a DECISION, pinned so it cannot become a surprise. Catching either
+    needs `analyze` — the recursive parser — which is the machinery whose
+    argv-and-nesting semantics generated ~24 review findings on the predecessor
+    of this change, and which would additionally pull this module into the
+    bare-analyze allowlist and back under a cost bound.
+
+    The fail direction is SILENCE, i.e. exactly the behaviour before this change
+    existed, so the miss costs nothing that was previously working. MEASURED over
+    2,659 real commands: a redirection-only first step occurs 0 times (0.00%),
+    and single-segment commands carrying an interpreter `-c` with inner
+    separators occur 25 times (0.94%) — an UPPER bound, since inspection shows
+    most are `python3 -c` where the `;` is Python syntax, not a shell step.
+
+    If that rate ever climbs, the answer is still not `analyze`: it is to ask
+    whether the note belongs at the refusal point at all.
+    """
+    assert dw.note(cmd) is None
+
+
 def test_the_prompt_note_warns_about_DECLINING_not_about_a_discard():
     text = dw.prompt_note(f"cd /x && {_PUSH}")
     assert text is not None and "Declining" in text
@@ -481,6 +513,47 @@ def test_live_a_poisoned_helper_can_never_fail_a_guard_open(tmp_path, script, re
         "CC treats any non-2 exit as non-blocking, so the refused command would RUN. "
         f"stderr: {proc.stderr[-600:]}"
     )
+
+
+def test_live_an_exception_generated_refusal_still_carries_the_note(tmp_path):
+    """`run_guard` turns an exception into exit 2 — a refusal like any other.
+
+    The reader sees only "GUARD ERROR ... failing CLOSED" and is told nothing
+    about the write two steps earlier. MEASURED before the fix: a crash injected
+    after the command is remembered gave rc=2 with the note ABSENT.
+
+    Residual, stated: the other run_guard-wrapped guards emit at their own
+    return-2 sites, so their exception paths still lack the note. Covering those
+    means emitting from `run_guard` itself, in `hook_input` — a stdlib-only
+    module bare-imported by 19 files, and already owned by the import-time
+    fail-closed work rather than by this change.
+    """
+    sandbox = tmp_path / "hooks"
+    sandbox.mkdir()
+    for f in _HOOKS.glob("*.py"):
+        shutil.copy2(f, sandbox / f.name)
+    guard = sandbox / "git_push_guard.py"
+    src = guard.read_text()
+    anchor = "        if discarded_write is not None:\n            discarded_write.remember(cmd)\n"
+    assert src.count(anchor) == 1, "anchor drifted — this test would inject nothing"
+    guard.write_text(src.replace(anchor, anchor + '        raise RuntimeError("injected")\n', 1))
+
+    proc = subprocess.run(
+        [sys.executable, str(guard)],
+        input=json.dumps(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "echo hi > /tmp/dw_probe && git " + "push"},
+                "cwd": str(_REPO),
+            }
+        ),
+        capture_output=True,
+        text=True,
+        cwd=str(_REPO),
+        timeout=120,
+    )
+    assert proc.returncode == 2, (proc.returncode, proc.stderr[-400:])
+    assert "ENTIRE command was discarded" in proc.stderr, proc.stderr[-600:]
 
 
 def test_live_the_ask_path_carries_the_prompt_note():


### PR DESCRIPTION
## What this does

A PreToolUse hook that exits 2 cancels the **whole** Bash call, not the step it objected to. So `cat > config.py <<'EOF' … EOF && git commit`, refused for the commit, **also loses the write** — and the message named only the commit. It reads as "the commit didn't happen," never "and the edit you just made is gone."

Every guard that can refuse a Bash command now says so at its own refusal point. The one guard that still has an approval path carries the same warning in the dialog, since declining also skips every other step. (It was two when this was written; #1861 has since removed the other, and the reconciliation is described below.)

## This replaces #1546, and the reduction is the point

#1546 spent eleven days and **8 external review rounds** on this idea and did not converge. Counting its ~30 findings by class rather than reading them one at a time, **every single one is about the predicate deciding *whether* to emit** — never the note, the wiring, the fail-open discipline, or the placement. Two generations of the same generator: *argv→effect* (14 findings, already deleted there) and *construct→step* (still live at its head).

So this is not #1546 rebased. It is the same feature with the generator removed — and it is opened on a new branch as **option (b) of the round-7 terminal: abandon and restart from a design that does not need seven rounds**, not as a way to reset a counter. The old branch's lifetime count stands as the reason this one exists.

**What is gone:** the `analyze` call, the `Segment.via` parser change, a private SIGALRM budget, two length/substitution proxies, and ~700 lines of tests for machinery that no longer exists. Four merge conflicts with main go to zero, because the parser is no longer touched at all.

## Three measurements decided the shape

**1 — the nesting apparatus bought nothing.** The full predicate and a one-line `len(split_segments(cmd)) > 1` disagree on **1 command in 2,659** (0.04%).

**2 — the private budget was redundant *and* harmful.** Since the shared parser gained its own bounds, a local budget is duplicated work with a worse failure mode. On a 65 KB command nested 40 deep, the old branch's timer fires mid-`analyze` and its blanket handler returns False — so budget ON gives no note, budget OFF gives the correct one, and the cheap sufficient check reaches the right answer in 0.049s. It suppressed correct notes on the exact adversarial shape it was added for.

**3 — listing the steps cannot work.** Replayed against the real defect, a step-echo renders:

```
  1. cat
  2. PORT=8080
  3. EOF
```

No filename, and heredoc body lines presented as commands. `parse_segments` splits on `|` as well as `&&`/`;` and retains no separator, and a plain-filename redirect target is dropped from both text views by design. Recovering either means the parser work that produced the five redirect-extraction findings. The acceptance replay killed that design before a line was written.

## Wording carries what the predicate cannot

`split_segments` splits on `|`, so a pure pipeline counts as multi-step — measured at **9.5% of firings** (219 of 2,303; a lower bound, counting only commands containing no `&&`/`||`/`;`/newline anywhere). A flat "an earlier step did not run" is false there. The note is phrased conditionally instead, and a test pins it.

## What it is worth, stated plainly

It fires on any multi-step command — **2,303 of 2,659 real commands (86.6%)** — and is load-bearing on the subset that actually carried a write, previously measured at 288 of 722 blocked multi-segment calls. Separating those needs the argv→effect mapping above. The ubiquity is the price of a note that cannot mislead, and this PR does not claim otherwise.

## Scope: nine python guards; the shell hook is deferred

A test derives the coverage set from `.claude/settings.json` — the CONFIGURATION, not the modules that happen to import the helper, which is structurally blind to a blocker nobody wired. **It immediately caught one**: `worktree_cwd_guard` was a configured blocker left out while eight siblings were done.

`bash_safety_hook.sh` and the inline settings.json blocker are **deliberately not in this PR**. Wiring them needs a new `EXIT` trap in a 471-line script that has neither a trap nor `set -e` today — the riskiest edit in the change, which should not ride along with the python wiring. A test records the deferral by name so the gap is a decision, not a hole. Those ~14 refusal sites carry no note until that PR lands.

`worktree_cwd_guard`'s Enter/ExitWorktree refusals are also un-noted: they carry an `action`, not a `command`, so there is no Bash call for the note to be about.

## Fail-open discipline

Every import is guarded with a sentinel and a null check, following `push_allowlist`'s precedent. An unguarded import that failed would abort module load → exit 1 → which Claude Code reads as a NON-blocking error → the guarded command runs. A cosmetic helper must never be able to do that, and a test asserts every consumer defines its stand-in.

`git_push_guard` has 28 scattered `return 2` sites and no `_deny` chokepoint, so its entry point is wrapped — covering all 28, and a 29th added tomorrow. A test asserts the wrapper is actually reached, because defined-but-unreferenced would still read as wired.

## Two internal reviews, run sequentially — and what they changed

**The security pass found a CRITICAL, verified by execution.** Three of the nine guards are not wrapped by `run_guard`, so an exception escaping a *cosmetic* helper exits 1 — which Claude Code reads as a non-blocking error — and the refused command runs. With a poisoned build of the helper, `git clean -fd` came back **rc=1** from `git_discard_guard`, whose own docstring promises a parser bug "can never become a silent ALLOW." I re-derived it independently before fixing:

```
BEFORE   git_discard_guard  rc=1   FAIL-OPEN (git clean -fd would RUN)
         full_suite_guard   rc=1   FAIL-OPEN
         background_pipe    rc=1   FAIL-OPEN
AFTER    all three          rc=2   fail-closed
```

Compounding it: `remember()` was the one public entry point without an internal `try/except`, while the module docstring claimed *every* entry point is fail-open — a docstring asserting a property the code didn't have. Fixed at both layers, and **locked by a test** that drives every guard with an all-raising helper and asserts exit 2; reverting one suppression makes it fail.

**The architecture pass found that three of my wiring locks were vacuous.** I re-derived all three rather than accepting them — 3/3 mutations survived: deleting one of two `warn()` sites, `remember(None)`, and `prompt_note()` with its result dropped all left the suite green. One generator: **the locks asserted AST structure where they must assert behaviour.** The fix wasn't three smarter predicates — it was promoting the live E2E out of a scratch script into the suite. After: 0/3 survive.

**Two proposed fixes declined, with reasons.** Reading `~/.claude/settings.json` in the coverage walk would make a repo test pass or fail by machine; instead the walk now resolves `bash <script>` hooks *in-repo*, and `bash_safety_hook.sh` — wired per-install at user level — is named by hand in a record that is now asserted in both directions, so wiring one means deleting its entry. And moving the API into `hook_input.py` to delete 32 ceremony sites was declined: `hook_input` is stdlib-only and imported bare by 19 files, so coupling it to `shell_parse` makes a cosmetic helper's failure reachable from the fail-closed wrapper's own module.

Accepted as advisory, unchanged: the note doubles where `bash_safety_hook.sh` re-invokes a guard the settings also wire directly (pre-existing duplication, in the deferred PR's surface), and `_NOTE` adds 387 chars to a refusal's stderr, which nothing currently budgets.

## Verification

561 targeted tests, `ruff`, and all five locally-reproducible CI guards clean.

A **differential of main against this branch** — 4 guards × 114 real commands — found **0/456 verdict changes**, with a live positive control proving the instrument can see a refusal. The change is cosmetic, measured rather than asserted.

**E2E on the real hooks, 18 cells** — for each guard: a multi-step refusal carries the note, a single-step refusal does not (also the guard-the-guard proof that the fixture really blocks), and an allowed command is untouched. Exit codes asserted unchanged in every cell.

**Verify-RED 9/9** over the locks. The first sweep had one survivor, and it was a real defect in the test rather than the code: `_calls(warn) or _calls(remember)` let a guard that remembers but never warns pass — the silently-inert shape the lock exists to prevent. Fixed to require both, re-swept clean.

E2E: after merge, in a live session run a multi-step Bash call whose later step a guard refuses (a file write chained with a refused push) and confirm the refusal carries the note exactly once; controls — a single-step refusal carries none, an allowed command carries none, and an approval prompt carries the prompt-tense variant.

Ledger: b49c994c3f3648e7a7cca8142c04afa1



---

## Rebased onto current main — and one test earned its keep

This PR sat four days while a background watcher that was meant to report its last two gates died with the session that armed it. In that window main moved three commits and **#1861 merged**, which deletes `review_enforcement_commit._ask` — the function this PR wires a prompt note into.

The merge therefore needed two resolutions in opposite directions:

- **`review_enforcement_commit.py` — base wins.** #1861's thesis is that the blind-spot net should refuse rather than prompt. Restoring `_ask` so this branch's wiring kept a consumer would have reverted that policy inside a merge commit, which is the one diff nobody re-reviews. The function and the wiring are gone together; the refusal wiring this PR is actually about survives, and `_deny` is still the sole chokepoint.
- **`git_push_guard.py` — both sides kept.** `_ask` survives there, so it is not a policy conflict: main added `_ASK_EMITTED` bookkeeping, this branch appends to `reason`. Independent, both intact.

**One test failed on the merge, which is exactly what it was for.** It asserted both files still had an ask path, so the deletion made it false and it failed with "no ask path left" rather than passing over a call into a function that no longer exists. It is now *derived* rather than literal — the set of guards with an ask path is not stable, so what must hold is the conditional, and a floor states plainly that if none survives anywhere then `prompt_note` should be deleted rather than left unwired.

An adversarial audit over the merged tree found no blocker and three things worth fixing, all applied. The sharpest: main **extracted `_run_merge_and_push_gates` out of `main()`**, moving all 28 `return 2` sites out of the function this PR's wrapper docstring named — AST-measured, `main()` now has **0**. The wrapper is still correct because `main()` returns the gate's code unchanged, but that invariant was locked by nothing except the prose describing it, and the prose had gone false twice over. A live test now drives the real guard to a real refusal through the extracted gates; swallowing the verdict turns it red.

Re-verified after the merge, because pre-merge numbers do not transfer: **598 targeted tests**, ruff, **E2E 18/18** on the real hooks with exit codes asserted unchanged, and the poisoned-helper matrix still refusing at all five probed guards — that last re-run mattered, since main rewrote this file substantially while the branch was idle.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer warnings when potentially destructive, unsafe, or incorrectly targeted commands are blocked.
  - Approval prompts now explain when declining an action will also skip related command steps.
  - Blocked piped, repository, worktree, and test-related commands provide more informative discard messages.

- **Bug Fixes**
  - Improved resilience so notification or messaging failures do not change command approval and blocking behavior.
  - Preserved existing enforcement outcomes for both allowed and refused commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->