### PR TITLE
feat(db): an atomic multi-statement transaction on the shared connection

### DIFF
--- a/changelog.d/20260909020000-added-atomic-db-transaction-primitive.md
+++ b/changelog.d/20260909020000-added-atomic-db-transaction-primitive.md
@@ -1,0 +1,10 @@
+- **Multi-statement database writes can now be made all-or-nothing.** Genesis
+  shares a single database connection across everything running at once, and
+  until now each statement was individually protected while a sequence of them
+  was not — so two writes that only make sense together could be split apart by
+  another task committing in between, leaving the first applied and the second
+  not. A new transaction block holds the connection for the whole sequence and
+  either applies all of it or none of it. Statements that would end the
+  transaction early are refused inside the block, on every path that reaches the
+  database — including the lower-level cursor that ordinary queries hand back,
+  which is the one that made the earlier guards incomplete.

--- a/src/genesis/db/connection.py
+++ b/src/genesis/db/connection.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import random
+import re
 import sqlite3
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
 from contextlib import asynccontextmanager, suppress
@@ -92,6 +93,41 @@ _JITTER_HIGH = 1.2
 _async_sleep = asyncio.sleep
 
 
+# Leading whitespace / `-- line` / `/* block */` comments before the first SQL
+# token. Used to find the statement's leading VERB for the transaction-control
+# refusal below — a denylist over the leading token only, deliberately NOT a SQL
+# parser: a miss (an unrecognised spelling) degrades to the pre-existing
+# behavior (statement forwarded), while a match fails LOUD before the statement
+# runs, so neither direction can silently corrupt a transaction.
+_LEADING_SQL_NOISE = re.compile(r"(?:\s+|--[^\n]*(?:\n|$)|/\*.*?\*/)*", re.S)
+
+# SQLite's transaction-control statement verbs. Inside an owned transaction()
+# block these fork the single-commit invariant exactly like calling
+# commit()/rollback() would (which _refuse_inside_txn already refuses) — an
+# early raw COMMIT makes later statements non-atomic, a raw ROLLBACK discards
+# the unit while the context manager still reports success, a raw BEGIN errors.
+# SAVEPOINT/RELEASE are included: the transaction() contract is "issue only
+# statement executes inside the block" — relaxing that for savepoints would be
+# a conscious, separate decision.
+_TXN_CONTROL_VERBS = frozenset({"begin", "commit", "end", "rollback", "savepoint", "release"})
+
+
+def _leading_sql_verb(sql: str) -> str:
+    """The statement's first keyword, lowercased (comments/whitespace skipped);
+    '' when none found.
+
+    A leading U+FEFF is stripped FIRST because Python's ``\\s`` does not match it
+    but SQLite skips it: without this, ``"\ufeffCOMMIT"`` reads as verbless here
+    and then executes for real (MEASURED). Reachable whenever SQL comes from a
+    file — ``open(encoding="utf-8")`` keeps a BOM; only ``utf-8-sig`` drops it.
+    """
+    m = _LEADING_SQL_NOISE.match(sql.lstrip("\ufeff"))
+    stripped = sql.lstrip("\ufeff")
+    rest = stripped[m.end() :] if m else stripped
+    verb = re.match(r"[A-Za-z_]+", rest)
+    return verb.group(0).lower() if verb else ""
+
+
 def _is_lock_error(exc: BaseException) -> bool:
     """True for SQLite lock errors: "database is locked" (SQLITE_BUSY) AND
     "database table is locked" (SQLITE_LOCKED), case-insensitive.
@@ -101,6 +137,61 @@ def _is_lock_error(exc: BaseException) -> bool:
     depend on it.
     """
     return isinstance(exc, sqlite3.OperationalError) and "locked" in str(exc).lower()
+
+
+class _GuardedCursor:
+    """A cursor handed out from INSIDE an owned :meth:`transaction` block, with
+    the transaction-control surface refused on it exactly as it is on the
+    connection.
+
+    Guarding :meth:`SerializedConnection.cursor` alone does not close this hole
+    and it is a mistake to think it does: ``execute()`` returns an
+    ``aiosqlite.Cursor`` too, so a body can obtain the same class through the
+    ordinary query path and commit through it. MEASURED before this wrapper
+    existed: ``cur = await conn.execute("SELECT 1"); await cur.execute("COMMIT")``
+    ended the transaction, and so did ``async with conn.execute(...)`` and
+    ``cur.executescript(...)`` — three escapes past a guard whose own comment
+    claimed to be the only door.
+
+    Everything else forwards untouched. The async-iteration and context-manager
+    protocols are declared explicitly because Python looks those up on the TYPE,
+    so ``__getattr__`` never sees them.
+    """
+
+    __slots__ = ("_cur", "_owner")
+
+    def __init__(self, cur: aiosqlite.Cursor, owner: SerializedConnection) -> None:
+        object.__setattr__(self, "_cur", cur)
+        object.__setattr__(self, "_owner", owner)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(object.__getattribute__(self, "_cur"), name)
+
+    async def execute(self, sql: str, parameters: Iterable[Any] | None = None) -> Any:
+        self._owner._refuse_txn_control_sql(sql)
+        return await self._cur.execute(sql, parameters)
+
+    async def executemany(self, sql: str, parameters: Iterable[Iterable[Any]]) -> Any:
+        self._owner._refuse_txn_control_sql(sql)
+        return await self._cur.executemany(sql, parameters)
+
+    async def executescript(self, sql: str) -> Any:
+        # Refused wholesale, like the connection method: a script carries an
+        # implicit COMMIT, so no per-verb check can make it safe here.
+        self._owner._refuse_inside_txn("cursor.executescript")
+
+    def __aiter__(self) -> Any:
+        return self._cur.__aiter__()
+
+    async def __anext__(self) -> Any:
+        return await self._cur.__anext__()
+
+    async def __aenter__(self) -> _GuardedCursor:
+        await self._cur.__aenter__()
+        return self
+
+    async def __aexit__(self, *exc_info: Any) -> Any:
+        return await self._cur.__aexit__(*exc_info)
 
 
 class SerializedConnection:
@@ -139,6 +230,8 @@ class SerializedConnection:
             "_reconnect_fn",
             "_consecutive_errors",
             "_max_errors",
+            "_txn_owner",
+            "_op_epoch",
         }
     )
 
@@ -155,6 +248,19 @@ class SerializedConnection:
         object.__setattr__(self, "_reconnect_fn", reconnect_fn)
         object.__setattr__(self, "_consecutive_errors", 0)
         object.__setattr__(self, "_max_errors", self._MAX_LOCK_ERRORS)
+        # The asyncio.Task holding an OPEN explicit transaction (via
+        # :meth:`transaction`), or None. Read on every DB op by _owns_txn(), so
+        # it MUST be initialized here and live in _OWN_ATTRS — otherwise the
+        # first op resolves it through __getattr__ against the wrapped
+        # connection and raises AttributeError before any transaction exists.
+        object.__setattr__(self, "_txn_owner", None)
+        # Monotonic count of DB operations that COMPLETED on this connection.
+        # :meth:`transaction`'s entry wait reads it to tell a CONTENDED
+        # connection (peers are committing; work is progressing; keep waiting)
+        # from a WEDGED one (a peer opened a write, died before commit, and
+        # nothing will ever close it). Without it the wait is progress-blind and
+        # a busy connection is misreported as a wedge.
+        object.__setattr__(self, "_op_epoch", 0)
 
     # -- Attribute passthrough (e.g. row_factory, in_transaction) ----------
 
@@ -176,7 +282,14 @@ class SerializedConnection:
         """Track lock errors and attempt reconnection after threshold."""
         count = self._consecutive_errors + 1
         object.__setattr__(self, "_consecutive_errors", count)
-        if count >= self._max_errors and self._reconnect_fn is not None:
+        # Never reconnect in the middle of an OPEN explicit transaction: swapping
+        # `_conn` here would silently discard the uncommitted transaction on the
+        # old connection and leave :meth:`transaction`'s COMMIT/ROLLBACK operating
+        # on a fresh, transaction-less connection. Integrity is preserved either
+        # way (the CAS + single commit means a discarded txn wrote nothing), so
+        # just count the episode and raise — transaction() then rolls back on the
+        # still-open connection and the caller retries the whole unit. (F-E)
+        if count >= self._max_errors and self._reconnect_fn is not None and not self._owns_txn():
             logger.warning(
                 "DB lock error %d/%d — attempting reconnection",
                 count,
@@ -235,6 +348,10 @@ class SerializedConnection:
             try:
                 result = await fn()
                 self._reset_error_count()
+                # Progress signal for transaction()'s entry wait: every completed
+                # op (execute/commit/rollback all route here) bumps the epoch, so
+                # a peer that is still WORKING is never mistaken for a wedge.
+                object.__setattr__(self, "_op_epoch", self._op_epoch + 1)
                 return result
             except sqlite3.OperationalError as e:
                 if not _is_lock_error(e):
@@ -262,6 +379,80 @@ class SerializedConnection:
         msg = "unreachable: retry loop exits via return or raise"
         raise AssertionError(msg)
 
+    # -- Transaction ownership (multi-statement atomicity) ------------------
+
+    def _owns_txn(self) -> bool:
+        """True iff the CURRENT task holds this connection's open explicit
+        transaction (opened via :meth:`transaction`).
+
+        Short-circuits on the common no-transaction case (``_txn_owner is None``)
+        WITHOUT calling ``asyncio.current_task()``, so the hot per-call locking
+        path pays only one attribute load + identity test when nothing is inside
+        a transaction — behavior-preserving vs the original ``async with
+        self._lock``.
+        """
+        return self._txn_owner is not None and self._txn_owner is asyncio.current_task()
+
+    @asynccontextmanager
+    async def _maybe_lock(self) -> AsyncIterator[None]:
+        """Acquire ``self._lock`` — UNLESS the current task already holds it via
+        an open :meth:`transaction` on this connection.
+
+        The lock is non-reentrant, and :meth:`transaction` holds it across the
+        whole ``BEGIN IMMEDIATE`` … COMMIT; a statement issued from inside that
+        block (same task) must therefore run on the ALREADY-held lock rather than
+        deadlocking on a re-acquire. When no transaction is active this is exactly
+        ``async with self._lock``.
+        """
+        if self._owns_txn():
+            yield
+        else:
+            async with self._lock:
+                yield
+
+    def _guard_cursor(self, cur: Any) -> Any:
+        """Wrap a cursor in :class:`_GuardedCursor` when the caller is inside an
+        owned transaction, so the transaction-control surface is refused on
+        EVERY cursor this class hands out — not just the one from
+        :meth:`cursor`. Outside a transaction the cursor is returned untouched,
+        so nothing on the hot path changes shape."""
+        return _GuardedCursor(cur, self) if self._owns_txn() else cur
+
+    def _refuse_inside_txn(self, op: str) -> None:
+        """Refuse a transaction-level op (commit/rollback/close/executescript)
+        issued from INSIDE an owned :meth:`transaction` block. The context
+        manager owns the single COMMIT/ROLLBACK; a body that committed or closed
+        mid-block would fork the all-or-nothing invariant the transaction exists
+        to provide. Mirrors the migration runner's ``_MigrationConnectionProxy``.
+        """
+        if self._owns_txn():
+            raise RuntimeError(
+                f"{op}() is not allowed inside transaction() — the transaction "
+                "context manager owns the single commit/rollback; issue only "
+                "statement executes inside the block"
+            )
+
+    def _refuse_txn_control_sql(self, sql: str) -> None:
+        """Refuse raw transaction-control SQL (``execute("COMMIT")`` etc.) from
+        INSIDE an owned :meth:`transaction` block — the raw-SQL spelling of what
+        :meth:`_refuse_inside_txn` refuses on the method surface. Without this, a
+        body's ``execute("COMMIT")`` bypasses the method-level guard and a later
+        exception can no longer roll back what was committed early, silently
+        forking the all-or-nothing invariant. Outside a transaction the verbs
+        pass through unchanged. ENUMERATED over src/ and scripts/: of the twelve
+        sites issuing transaction-control SQL, exactly one family routes through
+        this class — the migration runner (``db/migrations/runner.py``, via
+        ``_MigrationConnectionProxy``). The rest hold raw handles
+        (``aiosqlite.connect``, ``get_raw_db``, stdlib ``sqlite3``) and cannot
+        reach this guard at all."""
+        if self._owns_txn() and _leading_sql_verb(sql) in _TXN_CONTROL_VERBS:
+            raise RuntimeError(
+                f"transaction-control SQL ({_leading_sql_verb(sql).upper()}) is not "
+                "allowed inside transaction() — the transaction context manager "
+                "owns the single commit/rollback; issue only statement executes "
+                "inside the block"
+            )
+
     # -- Operations that return Result (support both await and async with) --
 
     def execute(
@@ -269,9 +460,12 @@ class SerializedConnection:
         sql: str,
         parameters: Iterable[Any] | None = None,
     ) -> Result:
-        async def _locked() -> aiosqlite.Cursor:
-            async with self._lock:
-                return await self._retry_locked(lambda: self._conn.execute(sql, parameters))
+        async def _locked() -> Any:
+            self._refuse_txn_control_sql(sql)
+            async with self._maybe_lock():
+                return self._guard_cursor(
+                    await self._retry_locked(lambda: self._conn.execute(sql, parameters))
+                )
 
         return Result(_locked())
 
@@ -281,12 +475,15 @@ class SerializedConnection:
         parameters: Iterable[Iterable[Any]],
     ) -> Result:
         async def _locked() -> aiosqlite.Cursor:
+            self._refuse_txn_control_sql(sql)
             # Materialize BEFORE the retry loop: a generator argument would be
             # consumed by a failed first attempt, so the retry would silently
             # execute zero/partial rows and "succeed".
             params = list(parameters)
-            async with self._lock:
-                return await self._retry_locked(lambda: self._conn.executemany(sql, params))
+            async with self._maybe_lock():
+                return self._guard_cursor(
+                    await self._retry_locked(lambda: self._conn.executemany(sql, params))
+                )
 
         return Result(_locked())
 
@@ -296,7 +493,8 @@ class SerializedConnection:
         parameters: Iterable[Any] | None = None,
     ) -> Result:
         async def _locked() -> list[aiosqlite.Row]:
-            async with self._lock:
+            self._refuse_txn_control_sql(sql)
+            async with self._maybe_lock():
                 return await self._retry_locked(
                     lambda: self._conn.execute_fetchall(sql, parameters)
                 )
@@ -309,7 +507,8 @@ class SerializedConnection:
         parameters: Iterable[Any] | None = None,
     ) -> Result:
         async def _locked() -> tuple | None:
-            async with self._lock:
+            self._refuse_txn_control_sql(sql)
+            async with self._maybe_lock():
                 return await self._retry_locked(lambda: self._conn.execute_insert(sql, parameters))
 
         return Result(_locked())
@@ -319,6 +518,7 @@ class SerializedConnection:
         # partially apply before the lock error, so re-running it is not
         # idempotent. Keeps the pre-retry behavior: count + re-raise.
         async def _locked() -> aiosqlite.Cursor:
+            self._refuse_inside_txn("executescript")  # (F-B) — see _refuse_inside_txn
             async with self._lock:
                 try:
                     result = await self._conn.executescript(sql)
@@ -334,10 +534,12 @@ class SerializedConnection:
     # -- Simple async operations -------------------------------------------
 
     async def commit(self) -> None:
+        self._refuse_inside_txn("commit")  # (F-B)
         async with self._lock:
             await self._retry_locked(lambda: self._conn.commit())
 
     async def rollback(self) -> None:
+        self._refuse_inside_txn("rollback")  # (F-B)
         # Retried like commit (idempotent in legacy isolation mode): a locked
         # ROLLBACK that never lands leaves in_transaction=True permanently —
         # the exact wedge this class exists to prevent. Previously this path
@@ -346,12 +548,186 @@ class SerializedConnection:
             await self._retry_locked(lambda: self._conn.rollback())
 
     async def close(self) -> None:
+        self._refuse_inside_txn("close")  # (F-B)
         async with self._lock:
             await self._conn.close()
 
-    async def cursor(self) -> aiosqlite.Cursor:
-        async with self._lock:
-            return await self._conn.cursor()
+    async def cursor(self) -> Any:
+        # Inside a transaction this returns a _GuardedCursor, not a raw one: a
+        # raw cursor can issue COMMIT with nothing here able to observe it.
+        # Guarding this method ALONE would be theatre — execute() hands out the
+        # same class — so the wrapper is applied at every cursor-returning site.
+        async with self._maybe_lock():
+            return self._guard_cursor(await self._conn.cursor())
+
+    # -- Multi-statement atomic transaction --------------------------------
+
+    @asynccontextmanager
+    async def transaction(self) -> AsyncIterator[SerializedConnection]:
+        """Hold the connection lock across an atomic ``BEGIN IMMEDIATE`` … COMMIT.
+
+        The multi-statement counterpart to the per-call locking every other
+        method uses. Statements issued on this connection FROM THE SAME TASK
+        inside the ``async with`` block run on the already-held lock (``execute``
+        & friends detect ownership via :meth:`_maybe_lock` and skip re-acquiring),
+        so no other coroutine can interleave a statement, commit, or rollback into
+        this transaction. That is what makes a read-modify-write — a
+        compare-and-set UPDATE followed by a dependent INSERT, say — atomic
+        against the other coroutines that share Genesis's single connection. The
+        per-call lock alone releases between the two statements, so a peer can
+        commit the half-open transaction and leave the pair applied apart.
+
+        Semantics: COMMIT on clean exit, ROLLBACK on ANY exception (the body's own
+        ``ValueError`` etc. included), then re-raise. ``commit``/``rollback``/
+        ``close``/``executescript`` — and raw transaction-control SQL through
+        ``execute``/``executemany`` (``COMMIT``/``ROLLBACK``/``BEGIN``/…) — are
+        REFUSED inside the block (they would fork the single-commit invariant);
+        only statement execution is allowed.
+
+        Entry waits out a peer coroutine's open IMPLICIT transaction (jittered,
+        lock released between checks) before issuing ``BEGIN IMMEDIATE``, so a
+        transaction() starting between another coroutine's ``execute()`` and its
+        ``commit()`` no longer fails with "cannot start a transaction within a
+        transaction". The wait distinguishes the two reasons a transaction can
+        be open and raises a DIFFERENT error for each: a WEDGE (no DB op
+        completed across the stall budget — a peer died before commit) versus
+        CONTENTION (peers keep committing, but no idle moment appeared within
+        the connection's ``busy_timeout`` budget; retry the unit).
+
+        NOT re-entrant (a nested ``transaction()`` on the same task raises). A
+        CHILD task that issues a statement on this connection from inside the
+        block is a *different* task, so it takes the normal lock path and BLOCKS
+        on the held lock — do not fan out concurrent writes inside a transaction.
+        """
+        if self._owns_txn():
+            raise RuntimeError("transaction() is not re-entrant on the same connection")
+        # Wait out a peer coroutine's IMPLICIT transaction before BEGIN. Ordinary
+        # CRUD does execute();commit() as TWO lock acquisitions, so between them
+        # the connection sits inside an implicit transaction (legacy isolation
+        # mode) with the lock RELEASED — a BEGIN IMMEDIATE issued in that window
+        # raises "cannot start a transaction within a transaction", which
+        # _retry_locked does not retry (it retries lock errors only). Retrying
+        # under the held lock could never help anyway: the peer needs this lock
+        # to land its commit. So: acquire, check idle, and if a peer's implicit
+        # transaction is open RELEASE and back off (jittered, bounded) so the
+        # peer's commit can proceed. The idle check is race-free once it passes —
+        # no other statement can run on the connection while we hold the lock, so
+        # nothing can open a transaction between the check and BEGIN.
+        #
+        # The wait is BOUNDED (same schedule as _WRITE_RETRY_DELAYS, ~1.75s of
+        # backoff): the gap being waited out is a peer's execute→commit window,
+        # normally sub-millisecond. An implicit transaction still open after the
+        # full schedule means a peer errored between execute and commit and
+        # nothing will close it until some later commit/rollback — failing LOUD
+        # there beats silently blocking every transaction() caller on a wedge.
+        # The budget counts STALLED checks only — consecutive samples that saw a
+        # transaction open AND no completed op since the previous sample. A peer
+        # that is committing bumps _op_epoch, which RESETS the stall count: a
+        # merely busy connection must not be reported as wedged (measured: a
+        # progress-blind bound failed ~6% of transaction() entries under a
+        # saturated writer while nothing was actually wedged).
+        stall_budget = len(_WRITE_RETRY_DELAYS) + 1
+        # Contention still needs an outer bound, or a permanently-saturated
+        # connection could starve this waiter forever. It is NOT a new invented
+        # number: it is this install's already-configured "how long may a writer
+        # wait for the database" knob (PRAGMA busy_timeout, env-tunable per
+        # process — 5s server default, 15s in MCP children), so it scales with
+        # the same operator decision every other wait on this connection obeys.
+        contention_deadline = asyncio.get_running_loop().time() + db_busy_timeout_ms() / 1000
+        stalls = 0
+        last_epoch = self._op_epoch
+        attempt = 0
+        while True:
+            await self._lock.acquire()
+            if not self._conn.in_transaction:
+                break  # idle — proceed, still holding the lock
+            epoch = self._op_epoch
+            progressed = epoch != last_epoch
+            last_epoch = epoch
+            stalls = 0 if progressed else stalls + 1
+            self._lock.release()
+            if stalls >= stall_budget:
+                logger.warning(
+                    "transaction(): giving up — a peer's implicit transaction has"
+                    " been open across %d consecutive checks with NO completed DB"
+                    " op in between. Either a coroutine opened a write and died"
+                    " before commit/rollback, or a long explicit transaction"
+                    " (e.g. the migration runner's raw BEGIN IMMEDIATE) holds the"
+                    " connection. Regression signal: this firing in a QUIET period"
+                    " points at an abandoned write, not contention.",
+                    stalls,
+                )
+                raise sqlite3.OperationalError(
+                    "transaction(): the connection has been inside another "
+                    f"coroutine's transaction across {stalls} consecutive checks "
+                    "with no DB op completing — a peer opened a write and never "
+                    "committed/rolled back, or a long explicit transaction is "
+                    "holding the connection"
+                )
+            if asyncio.get_running_loop().time() >= contention_deadline:
+                logger.warning(
+                    "transaction(): giving up after waiting out %.1fs of peer"
+                    " write traffic (busy_timeout budget) — the connection kept"
+                    " making progress, so this is CONTENTION, not a wedge; the"
+                    " caller should retry the whole unit.",
+                    db_busy_timeout_ms() / 1000,
+                )
+                raise sqlite3.OperationalError(
+                    "transaction(): could not find an idle moment on the shared "
+                    f"connection within the {db_busy_timeout_ms()}ms busy_timeout "
+                    "budget — peers kept committing (contention, not a wedge); "
+                    "retry the unit"
+                )
+            delay = _WRITE_RETRY_DELAYS[
+                min(attempt, len(_WRITE_RETRY_DELAYS) - 1)
+            ] * random.uniform(_JITTER_LOW, _JITTER_HIGH)
+            attempt += 1
+            logger.debug(
+                "transaction(): peer transaction open (stalls=%d/%d, progressed=%s)"
+                " — retrying in %.0fms",
+                stalls,
+                stall_budget,
+                progressed,
+                delay * 1000,
+            )
+            await _async_sleep(delay)
+        try:
+            object.__setattr__(self, "_txn_owner", asyncio.current_task())
+            began = False
+            try:
+                # Explicit IMMEDIATE: takes the write lock up front (no lazy
+                # read→write upgrade deadlock across processes) and makes the
+                # boundary unambiguous rather than relying on legacy implicit-BEGIN
+                # timing. A locked BEGIN opened no transaction, so _retry_locked
+                # re-running it is safe. Matches the migration runner's idiom.
+                await self._retry_locked(lambda: self._conn.execute("BEGIN IMMEDIATE"))
+                began = True
+                yield self
+                # COMMIT via the driver method, NOT execute("COMMIT"): under a WAL
+                # post-commit-autocheckpoint SQLITE_BUSY the commit frame is already
+                # durable and in_transaction is False, so _retry_locked's retry of
+                # .commit() no-ops (idempotent). execute("COMMIT") would instead
+                # raise "no transaction is active" and surface a SPURIOUS failure
+                # for an append that actually landed. (F-A)
+                await self._retry_locked(lambda: self._conn.commit())
+            except BaseException:
+                if began:
+                    try:
+                        await self._retry_locked(lambda: self._conn.rollback())
+                    except Exception:
+                        # A failed ROLLBACK must not mask the original error. The
+                        # connection may wedge in_transaction=True until the
+                        # reconnect threshold recovers it; log and re-raise the
+                        # real cause.
+                        logger.error("ROLLBACK after transaction() error failed", exc_info=True)
+                raise
+            finally:
+                # Clear ownership BEFORE the lock is released (the outer finally
+                # below releases it), so there is never a window where the lock
+                # is free but a stale owner would route ops lock-free.
+                object.__setattr__(self, "_txn_owner", None)
+        finally:
+            self._lock.release()
 
     # -- Async iteration support (used by some callers) --------------------
 

--- a/tests/test_db/test_connection.py
+++ b/tests/test_db/test_connection.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import contextlib
+import sqlite3
 
 import aiosqlite
 import pytest
@@ -234,3 +235,400 @@ async def test_get_db_foreign_keys_opt_out(tmp_path):
         assert (await cur.fetchone())[0] == 0
     finally:
         await db.close()
+
+
+# ── transaction(): multi-statement atomicity (F1) ─────────────────────────
+
+
+async def test_transaction_commits_on_clean_exit(sconn):
+    """Statements inside the block are committed as a unit on clean exit."""
+    async with sconn.transaction():
+        await sconn.execute("INSERT INTO t VALUES (1, 'a')")
+        await sconn.execute("INSERT INTO t VALUES (2, 'b')")
+    # visible AFTER the block (single commit at exit)
+    cur = await sconn.execute("SELECT count(*) as cnt FROM t")
+    assert (await cur.fetchone())["cnt"] == 2
+
+
+async def test_transaction_rolls_back_on_error(sconn):
+    """ANY exception in the block rolls the WHOLE transaction back — the first
+    insert must not survive when the block later raises."""
+    with contextlib.suppress(RuntimeError):
+        async with sconn.transaction():
+            await sconn.execute("INSERT INTO t VALUES (1, 'a')")
+            raise RuntimeError("boom")
+    cur = await sconn.execute("SELECT count(*) as cnt FROM t")
+    assert (await cur.fetchone())["cnt"] == 0  # rolled back
+    # connection is not wedged — a later normal write still works
+    await sconn.execute("INSERT INTO t VALUES (9, 'ok')")
+    await sconn.commit()
+    cur = await sconn.execute("SELECT count(*) as cnt FROM t")
+    assert (await cur.fetchone())["cnt"] == 1
+
+
+async def test_execute_is_reentrant_inside_transaction(sconn):
+    """execute() from the OWNING task inside the block runs on the held lock
+    (does not deadlock re-acquiring the non-reentrant lock)."""
+    async with sconn.transaction():
+        # would hang forever if execute() tried to re-acquire self._lock
+        await asyncio.wait_for(
+            sconn.execute("INSERT INTO t VALUES (1, 'reentrant')"), timeout=2.0
+        )
+    cur = await sconn.execute("SELECT val FROM t WHERE id = 1")
+    assert (await cur.fetchone())["val"] == "reentrant"
+
+
+async def test_transaction_holds_lock_across_body(sconn):
+    """The core mechanism: while task A is INSIDE an open transaction (paused
+    between statements), task B's execute() on the same connection BLOCKS until
+    A's transaction commits — no peer can interleave.
+
+    Verify-RED: make _maybe_lock always yield (never take the lock) and B is no
+    longer blocked, so 'b-done' appears before A is released and the final order
+    assertion fails."""
+    order: list[str] = []
+    a_inside = asyncio.Event()
+    release_a = asyncio.Event()
+
+    async def task_a():
+        async with sconn.transaction():
+            await sconn.execute("INSERT INTO t VALUES (100, 'a1')")
+            order.append("a-mid")
+            a_inside.set()
+            await release_a.wait()  # hold the transaction open
+            await sconn.execute("INSERT INTO t VALUES (101, 'a2')")
+            order.append("a-commit")
+
+    async def task_b():
+        await a_inside.wait()
+        order.append("b-attempt")
+        await sconn.execute("INSERT INTO t VALUES (200, 'b')")  # must block on held lock
+        order.append("b-done")
+
+    ta = asyncio.create_task(task_a())
+    tb = asyncio.create_task(task_b())
+    await a_inside.wait()
+    await asyncio.sleep(0.05)  # give B every chance to run — it must be blocked
+    assert "b-attempt" in order and "b-done" not in order
+    release_a.set()
+    await asyncio.gather(ta, tb)
+    # A's ENTIRE transaction committed before B's write ran
+    assert order == ["a-mid", "b-attempt", "a-commit", "b-done"]
+
+
+async def test_transaction_isolates_peer_from_uncommitted_write(sconn):
+    """ACCEPTANCE BAR — a deterministic replay of the exact fork defect F1 fixes.
+
+    A peer coroutine's ROLLBACK must not discard an uncommitted write that
+    belongs to another coroutine's atomic unit. Task A opens a transaction and
+    writes r1, then pauses (mid read-modify-write). While A is paused a peer B
+    issues rollback() on the SAME shared connection. With transaction() holding
+    the lock, B's rollback BLOCKS until A commits, so BOTH of A's rows survive.
+
+    Verify-RED: this is the real known-positive. Break the mechanism (make
+    transaction() release the lock during the body, i.e. the pre-F1 per-call
+    behavior) and B's rollback lands between A's two writes and discards r1 — the
+    final count is 1, not 2. Confirmed RED during development against a
+    lock-releasing transaction()."""
+    a_wrote_r1 = asyncio.Event()
+    release_a = asyncio.Event()
+
+    async def task_a():
+        async with sconn.transaction():
+            await sconn.execute("INSERT INTO t VALUES (1, 'a1')")
+            a_wrote_r1.set()
+            await release_a.wait()  # pause mid-unit, transaction still open
+            await sconn.execute("INSERT INTO t VALUES (2, 'a2')")
+
+    ta = asyncio.create_task(task_a())
+    await a_wrote_r1.wait()
+
+    # Peer rollback while A is paused — must block on the held transaction lock.
+    tb = asyncio.create_task(sconn.rollback())
+    await asyncio.sleep(0.05)
+    assert not tb.done()  # B's rollback is blocked, cannot nuke A's uncommitted r1
+
+    release_a.set()
+    await asyncio.gather(ta, tb)  # A commits both rows, THEN B's rollback no-ops
+
+    cur = await sconn.execute("SELECT count(*) as cnt FROM t")
+    assert (await cur.fetchone())["cnt"] == 2  # both survived — no peer contamination
+
+
+async def test_transaction_is_not_reentrant(sconn):
+    """A nested transaction() on the SAME task raises rather than deadlocking or
+    silently sharing the transaction."""
+    with pytest.raises(RuntimeError, match="not re-entrant"):
+        async with sconn.transaction():
+            async with sconn.transaction():
+                pass
+
+
+async def test_transaction_waits_out_concurrent_implicit_txn(sconn):
+    """Repro (Codex P1, PR #1576): ordinary CRUD does execute();commit() as TWO
+    lock acquisitions, so the connection sits inside an IMPLICIT transaction
+    (legacy isolation mode) between them with the lock released. A peer's
+    transaction() entering that window used to raise 'cannot start a transaction
+    within a transaction' (an error _retry_locked does not retry — it retries
+    lock errors only). transaction() must instead wait the implicit transaction
+    out and then proceed."""
+    # open an implicit transaction the way every CRUD helper does (no commit yet)
+    await sconn.execute("INSERT INTO t VALUES (1, 'implicit')")
+    assert sconn.in_transaction
+
+    async def peer_txn():
+        async with sconn.transaction():
+            await sconn.execute("INSERT INTO t VALUES (2, 'txn')")
+
+    tb = asyncio.create_task(peer_txn())
+    await asyncio.sleep(0.05)
+    # not failed — waiting for the implicit transaction to resolve
+    assert not tb.done()
+    await sconn.commit()  # the CRUD pair's second half lands
+    await asyncio.wait_for(tb, timeout=5.0)  # transaction() proceeds and commits
+    cur = await sconn.execute("SELECT count(*) as cnt FROM t")
+    assert (await cur.fetchone())["cnt"] == 2
+
+
+async def test_transaction_raises_loud_when_implicit_txn_never_resolves(sconn, monkeypatch):
+    """Bounded, not infinite: an implicit transaction a peer opened and never
+    commits (errored between execute and commit) can only be closed by a later
+    commit/rollback — transaction() gives up LOUDLY once the stall budget is
+    spent, instead of blocking every caller forever. The error must name the
+    WEDGE hypothesis, which is the true one here (no op completes)."""
+    from genesis.db import connection as conn_mod
+
+    slept: list[float] = []
+
+    async def fast_sleep(d):
+        slept.append(d)
+
+    monkeypatch.setattr(conn_mod, "_async_sleep", fast_sleep)
+    await sconn.execute("INSERT INTO t VALUES (1, 'wedged')")  # never committed
+    with pytest.raises(sqlite3.OperationalError, match="never committed/rolled back"):
+        async with sconn.transaction():
+            pass  # pragma: no cover — must not be reached
+    # spent exactly the stall budget (N checks → N-1 backoffs), no more
+    assert len(slept) == len(conn_mod._WRITE_RETRY_DELAYS)
+    # the lock is RELEASED on the exhaustion path — a leak here would surface as
+    # a HANG in a later test rather than a failure, so assert it explicitly
+    assert not sconn._lock.locked()
+    # the connection is not wedged further: resolving the implicit txn works
+    await sconn.commit()
+    async with sconn.transaction():
+        await sconn.execute("INSERT INTO t VALUES (2, 'after')")
+
+
+async def test_transaction_wait_is_progress_aware_not_blind(sconn, monkeypatch):
+    """A CONTENDED connection is not a wedged one. While peers keep completing
+    ops, the stall budget must RESET rather than burn down — a progress-blind
+    bound fails transaction() entries while nothing is actually wrong. Here a
+    peer holds an implicit transaction open across far more checks than the
+    stall budget, but keeps executing, so entry keeps waiting; when the peer
+    finally commits, the transaction proceeds."""
+    from genesis.db import connection as conn_mod
+
+    ticks = 0
+
+    async def peer_progresses_then_commits(d):
+        # Stand in for the backoff sleep: each time the waiter backs off, the
+        # peer completes another op (progress), until it finally commits.
+        nonlocal ticks
+        ticks += 1
+        if ticks <= 3 * (len(conn_mod._WRITE_RETRY_DELAYS) + 1):
+            await sconn.execute(f"INSERT INTO t VALUES ({100 + ticks}, 'peer')")
+        else:
+            await sconn.commit()
+
+    monkeypatch.setattr(conn_mod, "_async_sleep", peer_progresses_then_commits)
+    await sconn.execute("INSERT INTO t VALUES (1, 'peer-open')")  # implicit txn open
+    async with sconn.transaction():  # must NOT raise despite many busy checks
+        await sconn.execute("INSERT INTO t VALUES (2, 'mine')")
+    # waited out far more checks than a progress-blind budget would have allowed
+    assert ticks > len(conn_mod._WRITE_RETRY_DELAYS) + 1
+    cur = await sconn.execute("SELECT count(*) as cnt FROM t WHERE val = 'mine'")
+    assert (await cur.fetchone())["cnt"] == 1
+
+
+async def test_transaction_contention_bound_is_the_busy_timeout(sconn, monkeypatch):
+    """Contention still has an outer bound (a permanently-saturated connection
+    must not starve the waiter forever), and it is the connection's configured
+    busy_timeout — not an invented number. When peers keep progressing past
+    that budget, the error names CONTENTION, not a wedge."""
+    from genesis.db import connection as conn_mod
+
+    clock = {"t": 0.0}
+
+    async def progress_and_advance_clock(d):
+        # peer completes an op every backoff (so the stall budget never fires)
+        await sconn.execute("INSERT INTO t VALUES (NULL, 'peer')")
+        clock["t"] += 10.0  # blow past any plausible busy_timeout budget
+
+    monkeypatch.setattr(conn_mod, "_async_sleep", progress_and_advance_clock)
+    loop = asyncio.get_running_loop()
+    monkeypatch.setattr(loop, "time", lambda: clock["t"])
+    await sconn.execute("INSERT INTO t VALUES (1, 'peer-open')")  # implicit txn open
+    with pytest.raises(sqlite3.OperationalError, match="contention, not a wedge"):
+        async with sconn.transaction():
+            pass  # pragma: no cover — must not be reached
+    assert not sconn._lock.locked()  # released on this exhaustion path too
+
+
+async def test_txn_control_sql_refused_inside_transaction(sconn):
+    """Raw transaction-control SQL through execute()/executemany() inside an
+    owned transaction() block bypassed _refuse_inside_txn — an early COMMIT
+    breaks the all-or-nothing unit (a later exception can't roll back what was
+    already committed), and a raw ROLLBACK discards the unit while the context
+    manager still reports success. Refuse the verbs, same as commit()/rollback()."""
+    async with sconn.transaction():
+        await sconn.execute("INSERT INTO t VALUES (1, 'x')")
+        for bad in (
+            "COMMIT",
+            "commit",
+            "  ROLLBACK",
+            "BEGIN IMMEDIATE",
+            "END",
+            "-- sneaky\nCOMMIT",
+            "/* c */ COMMIT",
+            "SAVEPOINT sp1",
+            "RELEASE sp1",
+        ):
+            with pytest.raises(RuntimeError, match="not allowed inside transaction"):
+                await sconn.execute(bad)
+        with pytest.raises(RuntimeError, match="not allowed inside transaction"):
+            await sconn.executemany("COMMIT", [()])
+    # the refused statements didn't break the unit — it committed intact
+    cur = await sconn.execute("SELECT count(*) as cnt FROM t")
+    assert (await cur.fetchone())["cnt"] == 1
+
+
+async def test_txn_control_sql_allowed_outside_transaction(sconn):
+    """Control: OUTSIDE a transaction() block the refusal must not fire — the
+    migration runner and precompact legitimately issue BEGIN IMMEDIATE/COMMIT/
+    ROLLBACK through execute() on connections with no owned transaction."""
+    await sconn.execute("BEGIN IMMEDIATE")
+    await sconn.execute("INSERT INTO t VALUES (1, 'manual')")
+    await sconn.execute("COMMIT")
+    cur = await sconn.execute("SELECT count(*) as cnt FROM t")
+    assert (await cur.fetchone())["cnt"] == 1
+
+
+async def test_commit_rollback_close_refused_inside_transaction(sconn):
+    """commit/rollback/close/executescript are refused inside the block — the
+    context manager owns the single commit/rollback, so a body cannot silently
+    early-commit or discard the transaction. (F-B)"""
+    async with sconn.transaction():
+        await sconn.execute("INSERT INTO t VALUES (1, 'x')")
+        for bad in ("commit", "rollback", "close"):
+            with pytest.raises(RuntimeError, match="not allowed inside transaction"):
+                await getattr(sconn, bad)()
+        with pytest.raises(RuntimeError, match="not allowed inside transaction"):
+            await sconn.executescript("SELECT 1")
+    # the block still committed normally despite the refused calls
+    cur = await sconn.execute("SELECT count(*) as cnt FROM t")
+    assert (await cur.fetchone())["cnt"] == 1
+
+
+async def test_every_sql_taking_method_refuses_transaction_control(sconn):
+    """Every public method that forwards SQL to the driver must refuse
+    transaction-control verbs inside a transaction.
+
+    The guard was originally added to `execute` and `executemany` only, and two
+    sibling helpers taking the same first argument were missed — an early COMMIT
+    through either one persists the body's writes, so a later exception can no
+    longer roll them back and the all-or-nothing contract breaks silently.
+
+    The surface is asserted as an EXPLICIT SET rather than a floor: a `>= N`
+    bound passes just as happily when a method is LOST as when one is added, and
+    introspection keyed on the parameter name `sql` cannot see a sibling someone
+    spells `statement`. An exact set fails loudly in both directions and forces
+    whoever changed the surface to come here and decide.
+    """
+    import inspect
+
+    forwards_sql = {
+        name
+        for name, fn in inspect.getmembers(type(sconn), inspect.isfunction)
+        if not name.startswith("_") and "sql" in inspect.signature(fn).parameters
+    }
+    expected = {"execute", "executemany", "execute_fetchall", "execute_insert", "executescript"}
+    assert forwards_sql == expected, (
+        f"the SQL-forwarding surface changed: {forwards_sql ^ expected}. Guard the new "
+        "method with _refuse_txn_control_sql (or _refuse_inside_txn for a whole-method "
+        "refusal) and update this set."
+    )
+
+    await sconn.execute("CREATE TABLE IF NOT EXISTS t2 (id INTEGER PRIMARY KEY)")
+    async with sconn.transaction() as tx:
+        for name in sorted(forwards_sql):
+            fn = getattr(tx, name)
+            # Supply whatever else the signature REQUIRES, so a missing argument
+            # cannot masquerade as a refusal: a TypeError satisfies neither
+            # pytest.raises(RuntimeError) nor the match, but a laxer assertion
+            # here would have let one through.
+            sig = inspect.signature(fn)
+            extra = [
+                []
+                for pname, param in sig.parameters.items()
+                if pname != "sql" and param.default is inspect.Parameter.empty
+            ]
+            with pytest.raises(RuntimeError, match="not allowed inside transaction"):
+                await fn("COMMIT", *extra)
+
+
+async def test_a_cursor_from_execute_cannot_commit_the_transaction(sconn):
+    """`execute()` returns a cursor, so guarding `cursor()` alone is theatre.
+
+    MEASURED before the wrapper existed: three separate escapes ended the
+    transaction through a cursor obtained from the ordinary query path —
+    `await cur.execute("COMMIT")`, the same through `async with`, and
+    `cur.executescript(...)`. All three are pinned here, because the class of
+    defect is "a guard that closes one of four doors while claiming to be the
+    only door".
+    """
+    await sconn.execute("CREATE TABLE IF NOT EXISTS t3 (id INTEGER PRIMARY KEY)")
+
+    async with sconn.transaction() as tx:
+        cur = await tx.execute("SELECT 1")
+        with pytest.raises(RuntimeError, match="not allowed inside transaction"):
+            await cur.execute("COMMIT")
+        with pytest.raises(RuntimeError, match="not allowed inside transaction"):
+            await cur.executescript("SELECT 1")
+
+    async with sconn.transaction() as tx, tx.execute("SELECT 1") as cur2:
+        with pytest.raises(RuntimeError, match="not allowed inside transaction"):
+            await cur2.execute("COMMIT")
+
+    # And the cursor still WORKS for ordinary statements, or the guard is just a
+    # removal of the feature.
+    async with sconn.transaction() as tx:
+        cur3 = await tx.execute("INSERT INTO t3 (id) VALUES (7)")
+        assert cur3.rowcount == 1
+        rows = await (await tx.execute("SELECT id FROM t3 WHERE id = 7")).fetchall()
+        assert len(rows) == 1
+
+
+async def test_a_byte_order_mark_cannot_smuggle_a_commit(sconn):
+    r"""`\ufeff` is not matched by Python's `\s` but IS skipped by SQLite.
+
+    So a BOM-prefixed COMMIT read as verbless to the guard and then executed for
+    real (MEASURED). Reachable whenever SQL comes from a file: Python's
+    `open(encoding="utf-8")` keeps a BOM — only `utf-8-sig` strips it.
+    """
+    async with sconn.transaction() as tx:
+        with pytest.raises(RuntimeError, match="not allowed inside transaction"):
+            await tx.execute("\ufeffCOMMIT")
+        with pytest.raises(RuntimeError, match="not allowed inside transaction"):
+            await tx.execute("\ufeff  /* c */ ROLLBACK")
+
+
+async def test_a_cursor_outside_a_transaction_is_unwrapped(sconn):
+    """Outside a transaction nothing changes shape — the wrapper is scoped to
+    the case it exists for, so the hot path is untouched."""
+    cur = await sconn.cursor()
+    assert type(cur).__name__ != "_GuardedCursor"
+    cur2 = await sconn.execute("SELECT 1")
+    assert type(cur2).__name__ != "_GuardedCursor"
+    # transaction-control SQL still passes through outside a transaction
+    await sconn.execute("BEGIN")
+    await sconn.execute("ROLLBACK")


### PR DESCRIPTION
Split out of #1576 so it can be reviewed as what it actually is: a change to the connection layer **every subsystem's database access goes through**, rather than an appendix to a dark subsystem. #1576 keeps the federation code and rebases onto this once it lands.

## Why split

#1576 is 3,486 lines across 25 files and has been through five cross-model rounds against a cap of three. Five of its findings open with the words *"Fresh evidence after the earlier fix"* — the reviewer naming the churn. It bundles ~2,900 lines of a dark subsystem, whose consumer is unwritten, with a rewrite of the shared connection layer. All the live risk is in the second part, and reviewing an interface with no consumer is why each round kept finding new things.

The split paid for itself immediately. One focused audit of this code alone surfaced a defect five rounds on the combined PR had not — see below.

## What it does

Each statement on the shared connection is individually serialised; a *sequence* of them is not. A compare-and-set UPDATE followed by the INSERT that depends on it can be split apart by another coroutine committing in between. `transaction()` holds the lock across `BEGIN IMMEDIATE` … COMMIT, with statements from the same task running on the already-held lock. COMMIT on clean exit, ROLLBACK on any exception, then re-raise.

## The refusal surface, which is where the care went

A partial guard on an atomicity contract is worse than none, and this one was partial in three ways:

- **Transaction-control SQL was refused on only two of the four SQL-taking methods.** `execute_fetchall` and `execute_insert` forwarded it.
- **Guarding `cursor()` was theatre.** `execute()` returns an `aiosqlite.Cursor` too, so the same class was reachable through the ordinary query path. Measured, three escapes: `await cur.execute("COMMIT")`, the same through `async with`, and `cur.executescript(...)` — each ended the transaction while the context manager still reported success. The refusal now lives on a wrapper applied at every cursor-returning site, and is a no-op outside a transaction so the hot path is unchanged.
- **A UTF-8 BOM walked past the verb parser.** Python's `\s` doesn't match U+FEFF; SQLite skips it. So a BOM-prefixed COMMIT read as verbless and executed for real. Reachable from any `.sql` file saved by a BOM-writing editor, since reading with plain UTF-8 keeps a BOM.

## Risk today is nil, which is the argument for landing it now

`transaction()` has no callers — the consumer stays with the federation PR. So the ownership field is permanently unset in production, the conditional lock reduces to the previous unconditional one, and the five rewritten hot-path methods are behaviour-identical to `main` until the first caller lands. Every risk here is latent, and this is the cheapest moment to close it.

Enumerated rather than assumed: of the twelve transaction-control call sites across `src/` and `scripts/`, exactly one family routes through this class (the migration runner). `cursor()` has zero production callers. A docstring claiming the precompact script as a caller is corrected — it holds a raw stdlib handle and never reaches this class.

## Open decisions I did not make unilaterally

Three findings are named here rather than silently carried, because two are design calls and one widens the diff:

1. **An unbounded transaction body holds the process-wide connection lock**, and the entry-wait wedge detector structurally cannot diagnose it — it runs only after acquiring the lock being held. A whole-process stall was measured, with the reconnect recovery path deliberately disabled during a transaction. The obvious remedy is a default body timeout, but that is a real design choice about a primitive, with its own failure mode: killing a legitimately slow transaction. Worth deciding before the first caller.
2. **The verb parser is duplicated in the migration runner, and the copy there handles no comments**, so a commented transaction-control statement is refused here and accepted in a migration — the weaker parser guarding the higher-stakes path. The fix is for the runner to import from this module (this file is the lower level), which widens the diff into the migration runner, so it is raised rather than bundled into a split whose point was to narrow the surface.
3. **A child task touching the connection inside a block deadlocks unbreakably** if the parent awaits it (a `gather` inside a body). The docstring says "BLOCKS", which reads as "resolves at commit". Wording and a test belong with decision 1, since a body timeout converts the deadlock into a raised error.

## Verification

82 tests pass across the connection, write-retry and migration-runner suites. Both new guards verify-RED against a mutant with them removed, each failing on the primary assertion. The enumerating test asserts an exact set rather than a floor, so losing a method fails as loudly as adding one. One internal adversarial audit; every finding either fixed or named above.

E2E: after merge, no runtime behaviour changes until a caller exists — `transaction()` has no call sites, so the deployed path is provably identical. The E2E that matters belongs to the first consumer (#1576): a concurrent read-modify-write under load must apply both statements or neither.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wingedguardian/genesis-agi/pull/1881" target="_blank"><picture><source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=4"><img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=4" alt="Devin Review"></picture></a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added atomic database transactions with commit and rollback support.
  - Prevented transaction-control commands from bypassing managed transaction ownership.
  - Protected database cursors during active transactions.
  - Added safeguards for nested transactions and concurrent database access.

- **Bug Fixes**
  - Improved handling of contention, cancellations, lock errors, and interrupted transactions.
  - Added recovery and reconnection safeguards when transactions cannot be rolled back safely.
  - Improved isolation and reliability for concurrent database operations.
  - Ensured connections are safely quarantined when transaction protection cannot be restored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->