### PR TITLE
docs(skill): a reviewer session flags a dead PR, it does not retire it

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -2181,6 +2181,40 @@ this rule removes is only the WATCHING — unprompted gate-polling and
 review-soliciting between a push and the next external event. When you do
 merge, the Pre-Merge Gate below governs unchanged.
 
+### Never RETIRE a PR you are not the one reviving (standing user rule, 2026-09-08)
+
+Terminology first, because the section above already uses "closing" to mean
+merging: **RETIRING** is `gh pr close` — abandoning a PR unmerged. This rule is
+about that, and only that. Merging a green PR is unaffected.
+
+**A reviewer session retires nothing.** When a PR turns out to be wrong at the
+premise — the mechanism cannot work, the design is contested, the fix belongs on
+a different event — the disposition is `needs-architecture-session` **on the PR**,
+carrying the evidence, and the PR stays OPEN. Retiring it belongs to the session
+that actually takes up its revival, at the moment it takes it up.
+
+Why the split, since "it's clearly dead, just close it" is the rationalization
+this rule exists to stop:
+
+- **A reviewer has read the diff, not the intent.** You can establish that a
+  mechanism does not work. You cannot establish that nothing in the branch is
+  worth reviving, that the author holds no context you lack, or that the right
+  successor design does not reuse most of it.
+- **An open PR carrying an evidence-bearing comment is a live handoff; a closed
+  one is an archaeology task.** The next session finds an open PR by listing the
+  queue. It finds a closed one only if someone remembers it existed.
+- **Retiring costs the review record its addressability.** Threads on a closed
+  PR stop being where the conversation happens, so the reasoning that just cost
+  a review round stops being read.
+
+So: post the finding, flag it, leave it open, and let the reviving session
+decide — including deciding to retire it in favour of a successor, which is that
+session's call to make and to justify.
+
+The same holds for a superseded PR: name the successor in a comment and leave it
+open. If you believe a PR should be retired and nobody is picking it up, that is
+a question for the user, not a judgment call for the review station.
+
 ## Pre-Merge Gate
 
 **Canonical pre-merge check:** run

--- a/changelog.d/20260909040000-changed-reviewer-does-not-retire-prs.md
+++ b/changelog.d/20260909040000-changed-reviewer-does-not-retire-prs.md
@@ -1,7 +1,9 @@
-### Changed
-
-- A reviewer session now flags a premise-level defect with
-  `needs-architecture-session` and leaves the PR open, rather than retiring it.
-  Retiring a PR (`gh pr close`) belongs to the session that takes up its
-  revival. An open PR carrying the evidence is a live handoff; a closed one is
-  an archaeology task.
+- **A review session no longer closes a pull request it is not reviving.** When
+  a PR turns out to be wrong at the premise rather than in its details, it now
+  gets a `needs-architecture-session` comment carrying the evidence and stays
+  open; closing it belongs to whoever picks up the redesign, at the moment they
+  pick it up. An open PR with the reasoning attached is found by listing the
+  queue, and its review threads stay where the conversation is happening — a
+  closed one is found only if somebody remembers it existed. If a PR should be
+  closed and nobody is picking it up, that is a question for the maintainer
+  rather than a call the review station makes on its own.

--- a/changelog.d/20260909040000-changed-reviewer-does-not-retire-prs.md
+++ b/changelog.d/20260909040000-changed-reviewer-does-not-retire-prs.md
@@ -1,0 +1,7 @@
+### Changed
+
+- A reviewer session now flags a premise-level defect with
+  `needs-architecture-session` and leaves the PR open, rather than retiring it.
+  Retiring a PR (`gh pr close`) belongs to the session that takes up its
+  revival. An open PR carrying the evidence is a live handoff; a closed one is
+  an archaeology task.


### PR DESCRIPTION
Standing user ruling, given 2026-09-08 while a reviewer session was triaging a PR whose mechanism had been shown not to work.

## The rule

A reviewer station can establish that a PR's mechanism does not work. It cannot establish that nothing in the branch is worth reviving, that the author holds no context it lacks, or that the successor design will not reuse most of it. So the disposition for a premise-level defect is a `needs-architecture-session` comment carrying the evidence, with the PR left **OPEN**. `gh pr close` belongs to the session that takes up the revival, at the moment it takes it up.

In the user's words: *"you are not the one who should be closing anything. It needs to wait until the session that actually is going to take it up is open, and that's its responsibility to close it."*

## Why it needed the terminology paragraph

The section immediately above already uses "closing" to mean **merging** — `SKILL.md:2163`, *"**Closing a green PR.** ... merging it under the standing pre-approval ... is closing, not driving."* A new rule twenty lines below saying "never close a PR" would read as forbidding the merge that rule makes mandatory. The new section therefore opens by defining RETIRING as `gh pr close` and stating that merging a green PR is unaffected.

## Why an open PR is the better handoff

An open PR carrying an evidence-bearing comment is found by listing the queue. A closed one is found only if someone remembers it existed. Retiring also costs the review record its addressability: threads on a closed PR stop being where the conversation happens, so reasoning that cost a review round stops being read.

## It cannot strand a dead PR

The rule names its own exit: if a PR should be retired and nobody is picking it up, that is a question for the user, not a judgment call for the review station. The reviving session may also retire in favour of a successor — that is explicitly its call.

## Scope

Documentation only. 34 added lines in `.claude/skills/genesis-development/SKILL.md` plus a `changelog.d/` fragment. No runtime code, no test, no config.

A first attempt at this diff copied `SKILL.md` from a worktree that was behind `origin/main` and read +49/-185 — it would have reverted 185 lines of other sessions' skill work, including the existence-check section from #1876. Caught by reading `git diff --stat` rather than assuming a copy is additive; redone against the current file. Final diff verified at 41 insertions, 0 deletions.

E2E: none — documentation-only change to a model-facing skill file, no runtime surface, nothing to exercise post-merge.