### PR TITLE
docs(skill): keep the PR the PR — adjacent findings become issues

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -2224,6 +2224,43 @@ The same holds for a superseded PR: name the successor in a comment and leave it
 open. If you believe a PR should be retired and nobody is picking it up, that is
 a question for the user, not a judgment call for the review station.
 
+### Keep the PR the PR — adjacent findings become issues (standing user rule, 2026-09-09)
+
+**A review session's job is to get THAT PR merged.** Reviews routinely surface
+bugs that are real, pre-existing on `main`, and nothing to do with the diff in
+front of you. Those do not belong in the PR and they must not hold it up.
+
+Route every finding by ONE question — **does the PR work without this fixed?**
+
+- **No, the PR is broken without it** → fix it in this PR. The builder session
+  should have caught it, and shipping a PR that cannot function is not a merge.
+- **Yes, the PR works** → **file a GitHub issue and merge the PR.** Do not grow
+  the diff, do not open a discussion, do not park it in a reply and move on.
+
+**Standing approval to file, for this class only.** The user has granted
+blanket, ongoing approval to open GitHub issues for adjacent non-blocking bugs
+discovered during review. Do NOT ask per instance — asking each time was the
+friction this rule removes. That standing approval is scoped to exactly this
+case: an adjacent, non-blocking, already-existing defect found while reviewing.
+Every other public post still needs explicit per-instance approval.
+
+**The exception that is NEVER waived: a security defect is not filed publicly
+before it is fixed.** An unpatched bypass, a credential exposure, anything
+exploitable — that goes to a private record under `~/.genesis/output/` plus a
+`follow_up_create` row, and nothing about it reaches a public surface, this
+standing approval included. If a finding is both adjacent and a live bypass,
+the security rule wins.
+
+Write the issue while the context is in your head — the measurement, the
+file:line, the falsifier, and why it was out of scope for the PR. An issue that
+merely names a symptom costs the next session the whole investigation again, and
+you already did it.
+
+Why this is the rule: a review that widens into every adjacent defect stops
+being a review and becomes an unbounded refactor, which is how a two-finding PR
+turns into a six-round loop. The PR is the unit of work. The queue is the place
+the rest of it goes.
+
 ## Pre-Merge Gate
 
 **Canonical pre-merge check:** run

--- a/changelog.d/20260909140000-changed-adjacent-findings-become-issues.md
+++ b/changelog.d/20260909140000-changed-adjacent-findings-become-issues.md
@@ -1,0 +1,9 @@
+- **A code review that finds an unrelated bug now files it and lets the pull
+  request through.** Reviews regularly turn up real defects that already existed
+  and have nothing to do with the change being reviewed. The rule is one
+  question: does the change work without that fix? If it does, the finding
+  becomes a tracked issue and the change merges; only a defect that actually
+  breaks the change gets folded into it. This keeps a review from widening into
+  an open-ended cleanup, which is what turns a small change into a long series
+  of review rounds. A security defect is the exception and is never posted
+  publicly before it is fixed.


### PR DESCRIPTION
Standing rule from the repo owner, 2026-09-09, given after a review session asked whether an adjacent pre-existing bypass should hold up an unrelated PR. It should not, and the session should not have had to ask.

## The rule

A review session's job is to get **that** PR merged. Reviews routinely surface bugs that are real, already on `main`, and nothing to do with the diff in front of you.

One question routes every finding — **does the PR work without this fixed?**

- **No** → fix it in the PR. The builder session should have caught it; a PR that cannot function is not a merge.
- **Yes** → **file a GitHub issue and merge the PR.** Do not grow the diff, do not park it in a reply.

In the owner's words: *"the majority of issues, if they aren't blocking, if they aren't stopping the PR from being functional... those should just get filed as issues on GitHub automatically. Keep the PR the PR."*

## What this changes about approvals

CLAUDE.md requires explicit per-instance approval for every public post, because a public post is irreversible. This records a **standing** approval for one named case: an adjacent, non-blocking, already-existing defect found while reviewing. Every other public post still needs asking, and the text says so in the same paragraph so the carve-out cannot be read as a repeal.

## The exception that is not waived

**A security defect is never filed publicly before it is fixed.** An unpatched bypass, a credential exposure, anything exploitable — private record under `~/.genesis/output/` plus a `follow_up_create` row, and nothing reaches a public surface, this standing approval included. Where a finding is both adjacent and a live bypass, the security rule wins. That tiebreak is stated explicitly rather than left to inference, because this exact overlap came up twice in the session that produced the rule.

## Why it is worth a rule

A review that widens into every adjacent defect stops being a review and becomes an unbounded refactor — which is how a two-finding PR turns into a six-round loop. The PR is the unit of work; the issue queue is where the rest goes.

It also fixes the opposite failure, which was the more common one: an adjacent bug named in a PR reply and never tracked anywhere. The rule makes filing mandatory, not optional, and asks for the measurement and the file:line while the context is still in your head — an issue that only names a symptom costs the next session the whole investigation again.

## Scope

Documentation only. 37 added lines in `.claude/skills/genesis-development/SKILL.md` plus a `changelog.d/` fragment. No runtime code, no test, no config.

Placed as a `###` subsection under "When to DRIVE a Merge", immediately after the retire rule from #1887, since the three together now cover the full disposition space for a PR under review: merge it, leave it open and flagged, or file what does not belong in it.

E2E: none — documentation-only change to a model-facing skill file, no runtime surface, nothing to exercise post-merge.