### PR TITLE
fix(watchdog): state the grace's clock and reset contracts accurately

### DIFF
--- a/src/genesis/autonomy/watchdog.py
+++ b/src/genesis/autonomy/watchdog.py
@@ -237,20 +237,20 @@ class WatchdogChecker:
                 # ...but `uptime_s` belongs to whichever process WROTE the
                 # file. When a restart lands while the previous status.json is
                 # still inside the freshness window, that file is retained: its
-                # `uptime_s` is the PRIOR runtime's (stamped from that
-                # process's own bootstrap — see resilience/status_writer.py's
-                # `_bootstrap_completed_at` arithmetic) and its scheduler
-                # heartbeats describe a runtime that no longer exists. A large
-                # `uptime_s` therefore cannot establish that THIS process is
-                # old, and the first tick after boot would restart a healthy,
-                # still-bootstrapping server — the same defect the stale branch
-                # below closes, reached through the fresh/zombie path instead.
+                # `uptime_s` is the PRIOR runtime's (stamped from that process's
+                # own bootstrap — see status_writer.py `_bootstrap_completed_at`)
+                # and its scheduler heartbeats describe a runtime that no longer
+                # exists. A large `uptime_s` therefore cannot establish that THIS
+                # process is old, and the first tick after boot would restart a
+                # healthy, still-bootstrapping server — the same defect the stale
+                # branch below closes, via the fresh/zombie path instead.
                 # systemd's clock is the only reading tied to the CURRENT
-                # activation: a status file older than the unit's own uptime
-                # was written before the service started. (The comparison mixes
-                # a wall-clock age with a monotonic one; a wall-clock step can
-                # only inflate `staleness_s`, i.e. err toward suppressing, and
-                # the shared counter bounds that.)
+                # activation: a status file older than the unit's own uptime was
+                # written before the service started. (Mixed clock domains, and
+                # CLOCK_REALTIME steps BOTH ways: a forward step inflates
+                # `staleness_s`, erring toward suppression, which the counter
+                # bounds; a backward step deflates it, so the grace simply does
+                # not fire and this branch restarts as it did before it existed.)
                 service_uptime = self._service_uptime_s()
                 if (
                     service_uptime is not None
@@ -304,12 +304,12 @@ class WatchdogChecker:
         # activation, so a crash-loop that stays `active` at tick time would
         # renew the grace forever — which is why the grace is bounded by an
         # explicit skip counter (like every other suppression in this file),
-        # not by uptime alone. The counter clears with the rest of the state
-        # when a genuinely fresh status file appears (_reset_state), so a
-        # healthy bootstrap spends at most one skip. A failed probe suppresses
-        # nothing. The zombie branch above needs no equivalent — it only runs
-        # on a FRESH file, whose uptime_s field it already checks against
-        # stabilization_s.
+        # not by uptime alone. The counter clears with the rest of the state at
+        # _reset_state's FULL-reset branch (its post-restart stabilization
+        # cooldown branch preserves the count on purpose, exactly like
+        # consecutive_failures), so a healthy bootstrap spends at most one skip.
+        # A failed probe suppresses nothing. The zombie branch needs no
+        # equivalent: it runs only on a FRESH file, already uptime_s-checked.
         service_uptime = self._service_uptime_s()
         if (
             service_uptime is not None
@@ -345,7 +345,7 @@ class WatchdogChecker:
         freshness window, but carrying the previous process's heartbeats and
         `uptime_s`). They share ONE counter deliberately — a crash loop must
         not get a fresh budget per branch, and the counter clears for both when
-        a genuinely fresh status file appears (``_reset_state``).
+        a fresh status file reaches ``_reset_state``'s full-reset branch.
 
         Returns False — do not suppress — in exactly two cases: the bound is
         spent (logged + alerted once), or the incremented counter did not

--- a/tests/test_autonomy/test_watchdog.py
+++ b/tests/test_autonomy/test_watchdog.py
@@ -448,19 +448,19 @@ class TestStateCounterSanitization:
 
 class TestServiceUptimeProbe:
     """Drive the REAL _service_uptime_s body (the autouse fixture stubs it for
-    every other test, so nothing else executes the subprocess triage). Note the
-    subtlety pinned here: `systemctl show <nonexistent> --value` exits 0 with
-    output "0" (measured), so the `int(raw) == 0` clause — not the returncode
-    check — is the guard that actually rejects a never-activated unit.
+    every other test, so nothing else runs the subprocess triage). `systemctl
+    show <nonexistent> --value` exits 0 with "0" (measured), so `int(raw) == 0`
+    — not the returncode — rejects a never-activated unit. BOTH clocks are
+    injected below: a HOST-derived stamp went negative <42s after kernel boot.
     """
 
     def _real_uptime(self, checker: WatchdogChecker) -> float | None:
         return _REAL_SERVICE_UPTIME_S(checker)
 
-    def test_parses_monotonic_active_enter(self, tmp_path: Path, stale_status: Path):
+    def test_parses_monotonic_active_enter(self, tmp_path: Path, stale_status: Path, monkeypatch):
         checker = _make_checker(tmp_path, stale_status)
-        started = time.clock_gettime(time.CLOCK_MONOTONIC) - 42.0
-        fake = MagicMock(returncode=0, stdout=f"{int(started * 1e6)}\n")
+        monkeypatch.setattr(time, "clock_gettime", lambda _clock: 10_000.0)
+        fake = MagicMock(returncode=0, stdout=f"{int((10_000.0 - 42.0) * 1e6)}\n")
         with patch("genesis.autonomy.watchdog.subprocess.run", return_value=fake):
             uptime = self._real_uptime(checker)
         assert uptime is not None and 41.0 < uptime < 43.0


### PR DESCRIPTION
Follow-on to #1858. Three comment claims in the bootstrap-grace path were wrong, and one test could only pass on a host that had been up a while. Line-neutral: 27 insertions, 27 deletions.

## Why this is its own PR

The content was produced and tested during #1858's review and held. #1858 stood at 3 Codex rounds — exactly the cap — so pushing it there would have cost a round-4 request on a comment-and-test diff. #1858 merged at its reviewed head instead and this came onto its own branch, which starts at round 0. Nothing discarded, no round spent. The cherry-pick applied with no conflict, which is itself evidence the two changes were disjoint.

## The comment defects

**A false invariant about clock steps.** The comment asserted a wall-clock step "can only inflate `staleness_s`". It cannot only inflate.

The **behaviour** is fine, which is why nothing here changes control flow: `staleness_s > service_uptime` is an AND-condition on a SKIP path, so a backward correction means the grace does not fire and control falls through to the restart path that ran unconditionally before this feature existed. Worst case is a new protection failing to help, never a restart that would not otherwise happen. A backward step also deflates every heartbeat age, making the branch harder to enter. But a reader reasoning from the old sentence would conclude the opposite direction, so it now states what was measured.

**Two overstated the cooldown branch's contract.** It does return early with the grace counter intact. The code is deliberately unchanged: that branch stops counters resetting when a service flickers healthy then re-crashes, which is exactly the crash loop the bound exists to catch, so "fixing" it would weaken the bound. It is also unreachable at the shipped cadence — the timer is `OnUnitActiveSec=300` with a `Type=oneshot` runner, and `last_restart_at` is stamped in the same tick that restarts, so the next tick is at least 290s later, always past the 120s window.

## The test defect

It read real elapsed time. Established with a negative control **before** changing anything: at monotonic 10s the systemd stamp computes to a negative value, `isdigit()` rejects it, `uptime` resolves to `None` and the assertion fails; at 10000s it passes. So the test failed deterministically inside roughly the first 42 seconds of host uptime — invisible on a long-lived box, live on a fast-provisioned CI runner.

Both clocks are injected now, so it reads no wall clock at all.

This is the same class measured elsewhere on this repo the same day (see #1894): a wall-clock-coupled test that fails deterministically under one condition and passes under another, which is expensive precisely because the failure looks like a real regression.

## Verify-RED

Mutation `- int(raw) / 1e6` → `/ 1e3`. Proved applied: sha256 `710d1bdd…` → `8b94d6bb…`, `py_compile` clean so RED is behavioural not syntax. Test FAILED at `tests/test_autonomy/test_watchdog.py:466` with `assert (None is not None)` — a shape that also proves it exercises both the microsecond conversion and the `uptime >= 0` guard, so it cannot pass vacuously. Restored from a hash-gated copy, never `git checkout`.

Re-run after cherry-picking onto post-merge main: **149 passed**. That re-run matters — the original green was measured on the pre-merge branch, and a rebased change is not verified by its old test run.

## Known residual, out of scope

The mixed-domain comparison this documents (wall-clock `staleness_s` against monotonic `service_uptime`) remains. The only single-domain alternative is systemd's REALTIME stamp, which reintroduces the spoofing the monotonic read was chosen to avoid. That is a design change, not a comment correction.

E2E: none — comment corrections plus a test clock injection, no runtime behaviour change. The behaviour documented here shipped in #1858 and carries that PR's E2E.