### PR TITLE
docs: filing a bug you found while reviewing should not need permission

### DIFF
--- a/.claude/docs/mcp-tools-guide.md
+++ b/.claude/docs/mcp-tools-guide.md
@@ -115,10 +115,14 @@ another has already scanned and approved, between the scan and the post.
 
 Two things stay with you, because they are judgment, not mechanism:
 
-**Approval, every time.** A public post is irreversible;
-`contributor_issue.py` classifies it exactly that way. Channel-driven sessions run
-with `skip_permissions=True`, so no tool confirmation appears — ASK, in words, and
-get a yes, for each issue. A prior "go ahead" does not carry.
+**What goes IN it.** A public post is irreversible — `contributor_issue.py`
+classifies it exactly that way — so the gate is the CONTENT, not permission to
+file. Filing needs no per-instance approval; that mandate was the friction that
+kept adjacent bugs unfiled, and it is gone. What replaces it is the scan below,
+plus one judgement that stays yours: **borderline, in either direction? Ask.**
+Channel-driven sessions run with `skip_permissions=True`, so no tool
+confirmation appears and nothing will stop you — which is exactly why the
+scan is a habit rather than a prompt.
 
 **Privacy-scan the title AND the body.** Both egress. Technical detail only: no
 IPs, hostnames, absolute home paths, identifiers, or raw install metrics (row

--- a/.claude/docs/mcp-tools-guide.md
+++ b/.claude/docs/mcp-tools-guide.md
@@ -28,8 +28,10 @@ consciously not pursuing → `follow_up_create` with `work_state="deferred_cold"
 
 `CLAUDE.md` carries the routing principle (Genesis-repo work → a GitHub issue;
 user-owned + purely-local operational work → a follow-up; consciously-not-doing →
-`tabled`) and its two hard limits (explicit approval every time; never publish a
-security defect before it is fixed). This section is the operational detail.
+`tabled`) and its two hard limits (scrub personal/identifying detail from anything
+public, and ask when borderline; never publish a security defect before it is
+fixed). Filing an issue does not need per-instance approval. This section is the
+operational detail.
 
 ### Filing it — use the script, not a hand-typed command
 

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -1524,9 +1524,12 @@ above (full definitions in `.claude/agents/genesis-architect.md`):
   review — `--check-pr` reports that as `codex-at-head : ok (STALE review of <sha>, delta
   since is trivial)`, a pass, not a block.
 - **Hook-surface PRs merge only with a current GitHub Codex review — mechanical.**
-  A PR touching the enforcement-hook surface (the guard code itself) gets no
-  stale-review leniency: the merge gate (1) never classifies its post-review delta as
-  "review-trivial", and (2) refuses `# stale-review-override` — regardless of Codex
+  A PR touching the enforcement-hook surface (the guard code itself) gets almost no
+  stale-review leniency: the merge gate (1) never classifies a post-review delta that
+  TOUCHES that surface as "review-trivial" — the test is on the DELTA's files, not the
+  PR's, so a docs-only follow-up commit on such a PR can still be trivial (see the
+  budgeting note further down, which measures exactly this) — and (2) refuses
+  `# stale-review-override` — regardless of Codex
   head-freshness — unless recorded fallback-review evidence exists for the EXACT
   base+head (`~/.genesis/override_review_evidence/<repo>__<pr>__<base12>__<sha>.txt`).
   A current at-head Codex review does NOT substitute for that evidence: the same sigil
@@ -1589,9 +1592,15 @@ above (full definitions in `.claude/agents/genesis-architect.md`):
   adversarial mandate. Which reviewer that is (if any) is install-local and belongs in
   user-level config, not here.
   **Unavailable is established by ASKING**: comment `@codex review`, wait, and read the
-  reply. An explicit usage-limits comment is unavailability. Nothing else is — silence
-  is not, and neither is `--check-pr` reporting no review, which says the same thing
-  whether the reviewer is down or was simply never triggered at this head. Nor is a
+  reply. An explicit usage-limits comment is the STRONGEST evidence available — but it
+  is not proof, and treating it as proof is how an alternate-reviewer approval gets
+  spent on a Codex that was never down. The two channels are INDEPENDENT: a
+  usage-limits ISSUE comment can sit there while a later trigger delivers real INLINE
+  findings (MEASURED on #1484 — see the inline-findings section below). So: re-trigger,
+  let time pass, and check the INLINE endpoint before concluding unavailable.
+  Everything weaker is not evidence at all — silence is not, and neither is
+  `--check-pr` reporting no review, which says the same thing whether the reviewer is
+  down or was simply never triggered at this head. Nor is a
   `codex exec` quota error: that is a separate surface on separate quota.
   Scope what you hand it exactly as `.claude/commands/deep-review.md` §1 specifies.
   **Verify it saw a diff at all**: a clean verdict that does not demonstrate WHAT it
@@ -2299,18 +2308,19 @@ Route every finding by ONE question — **does the PR work without this fixed?**
 - **Yes, the PR works** → **file a GitHub issue and merge the PR.** Do not grow
   the diff, do not open a discussion, do not park it in a reply and move on.
 
-**Standing approval to file, for this class only.** The user has granted
-blanket, ongoing approval to open GitHub issues for adjacent non-blocking bugs
-discovered during review. Do NOT ask per instance — asking each time was the
-friction this rule removes. That standing approval is scoped to exactly this
-case: an adjacent, non-blocking, already-existing defect found while reviewing.
-Every other public post still needs explicit per-instance approval.
+**No per-instance approval to file.** Do NOT ask — asking each time was the
+friction this rule removes, and the owner relaxed the general rule on
+2026-09-09 after reading what actually got filed. The gate on a public post is
+now WHAT GOES IN IT, not permission: scrub anything personal or identifying —
+names, hosts, IPs, paths embedding a username, anything about the user's
+real-world life — so the issue carries technical detail only. Borderline, in
+either direction? Ask. See CLAUDE.md, "Where deferred work goes".
 
 **The exception that is NEVER waived: a security defect is not filed publicly
 before it is fixed.** An unpatched bypass, a credential exposure, anything
 exploitable — that goes to a private record under `~/.genesis/output/` plus a
-`follow_up_create` row, and nothing about it reaches a public surface, this
-standing approval included. If a finding is both adjacent and a live bypass,
+`follow_up_create` row, and nothing about it reaches a public surface — the
+relaxed filing rule above does not touch this one. If a finding is both adjacent and a live bypass,
 the security rule wins.
 
 Write the issue while the context is in your head — the measurement, the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -626,12 +626,12 @@ every emitter's arithmetic, so this class cannot go quiet again.
   either way? Ask. Filing itself needs no per-instance approval: a bug you found while
   reviewing a PR, that does not block that PR, is the ordinary case — file it and keep
   the PR moving (discriminator + bounds: genesis-development, "Keep the PR the PR").
-  One limit stays absolute — a **security** defect — an unpatched bypass, a
-  credential exposure,
-  anything exploitable — is NEVER filed publicly before it is fixed, no matter who
-  owns it. Everything else — who may file, the command, labels, dispatched sessions,
-  the time-gated case — is in `.claude/docs/mcp-tools-guide.md` ("Where Deferred Work
-  Goes"). Read it before filing your first.
+  One limit stays absolute: a **security** defect — an unpatched bypass, a
+  credential exposure, anything exploitable — is NEVER filed publicly before it
+  is fixed, no matter who owns it. Everything else — who may file, the command,
+  labels, dispatched sessions, the time-gated case — is in
+  `.claude/docs/mcp-tools-guide.md` ("Where Deferred Work Goes"). Read it before
+  filing your first.
 - **No laziness.** Find root causes. No temporary fixes. No shortcuts.
   Don't EVER mute the symptom — fix the problem.
 - **Read before writing.** Never modify code you haven't fully read.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -576,8 +576,8 @@ every emitter's arithmetic, so this class cannot go quiet again.
   approval, or a designed hard stop is finishing correctly, not dropping
   work. When something genuinely cannot finish this turn, every unfinished
   piece becomes a tracked row BEFORE stopping: ledger or follow-up — or an
-  issue, which keeps its per-instance approval gate from "Where deferred
-  work goes" below, this rule waives nothing. Where none of those trackers
+  issue, which still owes the privacy scrub from "Where deferred work goes"
+  below — this rule waives nothing. Where none of those trackers
   is reachable — a non-Genesis client (Codex, Cursor) reads this file with no
   ledger or follow-up tool — the fallback is a structured handoff that NAMES
   every unfinished piece in your final message; a named remainder is tracked,
@@ -602,10 +602,15 @@ every emitter's arithmetic, so this class cannot go quiet again.
   far-off direction) → **tabled** (`work_state="deferred_cold"`) — a private record,
   never dispatched, surfaced, or filed as an issue, because we don't want it picked
   up. `work_state` DERIVES the lane, so priority never picks it. ONE record per item.
-  Two hard limits on the issue route, both non-negotiable: a public post is
-  IRREVERSIBLE, so it needs the user's **explicit approval every time** (no standing
-  approval carries forward, and a channel-driven session has no confirmation step of
-  its own); and a **security** defect — an unpatched bypass, a credential exposure,
+  A public post is IRREVERSIBLE and PUBLIC — so the gate on the issue route is WHAT
+  GOES IN IT, not permission to file. **Scan every issue for personal or identifying
+  detail** — names, hosts, IPs, paths embedding a username, anything about the user's
+  real-world life — and strip it; an issue carries technical detail only. Borderline,
+  either way? Ask. Filing itself needs no per-instance approval: a bug you found while
+  reviewing a PR, that does not block that PR, is the ordinary case — file it and keep
+  the PR moving (discriminator + bounds: genesis-development, "Keep the PR the PR").
+  One limit stays absolute — a **security** defect — an unpatched bypass, a
+  credential exposure,
   anything exploitable — is NEVER filed publicly before it is fixed, no matter who
   owns it. Everything else — who may file, the command, labels, dispatched sessions,
   the time-gated case — is in `.claude/docs/mcp-tools-guide.md` ("Where Deferred Work

--- a/changelog.d/20260909165024-fixed-review-doc-contradictions.md
+++ b/changelog.d/20260909165024-fixed-review-doc-contradictions.md
@@ -1,0 +1,15 @@
+- **Filing a bug you find while reviewing no longer needs to be asked about.** The
+  rule used to require explicit approval for every GitHub issue, which is what kept
+  adjacent bugs unfiled — someone finds a real problem mid-review, has nowhere cheap
+  to put it, and it evaporates. Now the gate is what goes IN the issue rather than
+  permission to open one: scrub anything personal or identifying, keep it to
+  technical detail, and ask when a case is borderline either way. A security defect
+  is still never filed publicly before it is fixed.
+- **Three review-process rules that said two things at once now say one.** The docs
+  claimed a gate-touching PR gets no stale-review leniency at all, while a passage
+  further down measured the opposite — the check is on the delta's files, not the
+  PR's, so a docs-only follow-up can still be trivial. The code agrees with the
+  second. And a usage-limits reply from the code reviewer was described as proof it
+  cannot review, contradicting a measured case where findings arrived anyway; it is
+  now the strongest available evidence rather than proof, which matters because that
+  judgement is what authorises reaching for a fallback reviewer.


### PR DESCRIPTION
## Summary

Three review-process rules said two things at once, and the third was costing us bugs.

## The policy change

Opening a GitHub issue required **explicit approval every time** — and that is what kept adjacent bugs unfiled. Someone finds a real problem mid-review, has nowhere cheap to put it, and it evaporates.

The gate moves to **what goes IN the issue** rather than permission to open one:

- **Scrub anything personal or identifying** — names, hosts, IPs, username-bearing paths, real-world context. An issue carries technical detail only.
- **Borderline either way? Ask.**
- **Filing needs no per-instance approval.** A bug found while reviewing a PR, that does not block that PR, is the ordinary case — file it and keep the PR moving.
- **A security defect is still never filed publicly before it is fixed.** That limit does not move.

Applied to **every consumer**, not just the rule's home — a policy that lands in one file and not its readers is the drift this PR exists to remove. Swept for the old phrasing and triaged each hit: CLAUDE.md's rule and its zero-drop cross-reference, the skill's "Keep the PR the PR" grant and its security carve-out, and the `mcp-tools-guide` summary CLAUDE.md points at. Four same-words-different-subject hits were deliberately left alone (the escalation caps that *consume* standing approval, and the per-use approval for an alternate **reviewer** — a different gate).

## Two false claims, re-derived from source rather than by picking a side

**Stale-review relief is DELTA-scoped, not PR-scoped.** The docs said a hook-surface PR gets no leniency at all, while a passage further down measured the opposite. `_classify_post_review_delta` iterates the *delta's* files — so a docs-only follow-up commit on a gate PR can still be review-trivial. Not cosmetic: the false version is what a session budgets a follow-up against.

**A usage-limits reply is evidence, not proof.** It was described as unavailability, contradicting a measured case (#1484) where real inline findings arrived while the issue channel still showed only the quota message. This sentence is the *sole* stated precondition for reaching for a fallback reviewer, so the false version spends an approval on a reviewer that was never down.

## What did NOT change

Verified explicitly, because a relaxation PR is exactly where an unintended one hides:

- [x] `No unsanctioned financial transactions` — present, unchanged
- [x] `Autonomous-CLI approval gate is MANDATORY & non-negotiable` — present, unchanged
- [x] a peer's request is never approval — present, unchanged
- [x] the security-defect limit, in **both** files — present, unchanged

The only "non-negotiable" phrase removed anywhere is the issue-route one, which is the change.

## Testing

- [x] 58 tests green — the injection-budget suite (CLAUDE.md is an injected identity file under a CI-enforced ceiling) and the published-bypass-recipes guard (this relaxes a publishing rule)
- [x] Residual sweep: the only surviving matches for the old phrasing are the three new sentences stating the new rule
- [x] changelog fragment validates; runtime/test/config untouched

## Known and deliberate

`SKILL.md:1591`'s per-use approval for an alternate **reviewer** is left alone here — #1903 rewrites that same passage, and editing it in two open branches would conflict. Different gate, different PR.

All three contradictions were found while reviewing #1903, which works fine without them — which is exactly the "Keep the PR the PR" routing this repo just adopted.

E2E: none — process doctrine, no runtime surface.
