### PR TITLE
fix(hooks): a command name the shell builds is unestablished, not absent

### DIFF
--- a/changelog.d/20260909180000-fixed-shell-built-command-names-are-unestablished.md
+++ b/changelog.d/20260909180000-fixed-shell-built-command-names-are-unestablished.md
@@ -1,0 +1,14 @@
+- **A command whose operation the shell assembles is now treated as unknown
+  rather than as harmless.** The shared parser behind the approval guards uses
+  Python's shell tokenizer, which reproduces quoting faithfully but performs no
+  expansion at all. A word built by the shell therefore parses cleanly into
+  something other than what actually runs, and when that word is the one
+  choosing the operation, the guards saw a tidy parse naming nothing they gate —
+  the same answer they give for a command that gates nothing at all. The parser
+  now marks such a segment and reports it, so an operation it cannot establish
+  routes to the existing "ask a human" path instead of a confident all-clear.
+  The rule is stated as what it accepts rather than as a list of the forms that
+  fool it, so spellings nobody has thought of are covered too. Measured against
+  129,179 real commands from this install's history, 14 change how they are
+  read; ordinary work that interpolates a variable into an argument, a path, or
+  a `gh api` endpoint is untouched.

--- a/changelog.d/20260909180000-fixed-shell-built-command-names-are-unestablished.md
+++ b/changelog.d/20260909180000-fixed-shell-built-command-names-are-unestablished.md
@@ -13,6 +13,8 @@
   too. Two further constructs are named in the code as deliberately uncovered,
   with the reason for each, because the recurring mistake on this file is
   claiming a set is complete. Measured against 129,179 real commands from this
-  install's history, 14 change how they are read; ordinary work that
-  interpolates a variable into an argument, a path, or a `gh api` endpoint is
-  untouched.
+  install's history, 15 change how they are read, every one of them from a
+  silent allow to a prompt; ordinary work that interpolates a variable into an
+  argument, a path, or a `gh api` endpoint is untouched. A sibling guard that
+  answered an unreadable command by falling back to a weaker check now runs both,
+  because the weaker check cannot see the most destructive shapes.

--- a/changelog.d/20260909180000-fixed-shell-built-command-names-are-unestablished.md
+++ b/changelog.d/20260909180000-fixed-shell-built-command-names-are-unestablished.md
@@ -7,8 +7,12 @@
   the same answer they give for a command that gates nothing at all. The parser
   now marks such a segment and reports it, so an operation it cannot establish
   routes to the existing "ask a human" path instead of a confident all-clear.
-  The rule is stated as what it accepts rather than as a list of the forms that
-  fool it, so spellings nobody has thought of are covered too. Measured against
-  129,179 real commands from this install's history, 14 change how they are
-  read; ordinary work that interpolates a variable into an argument, a path, or
-  a `gh api` endpoint is untouched.
+  Two word-generating constructs are covered — substitution and brace expansion
+  — and the rule for each is stated as what it accepts rather than as a list of
+  the spellings that fool it, so spellings nobody has thought of are covered
+  too. Two further constructs are named in the code as deliberately uncovered,
+  with the reason for each, because the recurring mistake on this file is
+  claiming a set is complete. Measured against 129,179 real commands from this
+  install's history, 14 change how they are read; ordinary work that
+  interpolates a variable into an argument, a path, or a `gh api` endpoint is
+  untouched.

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -183,6 +183,13 @@ _GATED_MENTION = re.compile(
 _GH_MENTION = re.compile(r"\bgh\b")
 _CREATE_MENTION = re.compile(r"\bcreate\b")
 
+#: The programs whose SUBCOMMAND this guard gates. Used on the blind path to ask
+#: whether a segment that resolved to one of them left its operation unreadable —
+#: the one blind-spot shape `_mentions_gated_op` structurally cannot see, because
+#: the operation's name is the missing part. Every gated op in this file is a
+#: subcommand of one of these two.
+_GATED_EXES = frozenset({"git", "gh"})
+
 
 def _mentions_gated_op(command: str) -> bool:
     """Whether the RAW text names any gated operation, on the blind path only."""
@@ -7111,11 +7118,33 @@ def _run_merge_and_push_gates() -> int:
         # turns an allow into a prompt, or into a refusal when unattended.
         #
         # A mutation test proves nothing about an axis its cells do not vary.
+        # `_mentions_gated_op` is the conjunct that keeps this net narrow, and it
+        # rests on an assumption that holds for every blind-spot cause but one: that
+        # the operation is still SPELLED in the raw text, and only the structure
+        # around it is unreadable. A segment that resolves to git or gh with a verb
+        # the shell builds is the case where the unreadable part IS the operation's
+        # name — the text test is then asked about a word that is not there to find,
+        # and it answers "no gated op" with the same confidence for a command that
+        # has none. Requiring it there would make this net's trigger depend on
+        # whoever wrote the command choosing to spell the operation out.
+        #
+        # Read off the SEGMENT rather than off `blind`, deliberately: which programs
+        # are gated is this guard's question, and shell_parse keeps its BlindSpot to
+        # a single decision field for reasons its own class docstring measures. The
+        # exe test is what keeps the widening affordable — a segment whose PROGRAM
+        # is a variable is not established as git at all, and MEASURED over 129,179
+        # real commands those are 1,845 (interpreters and remote shells held in
+        # variables, plus prose) against 14 for the case this adds. Those 1,845 still
+        # reach this net through `_mentions_gated_op` whenever the operation is
+        # spelled, which is the honest split: an unreadable program naming a publish
+        # is worth one confirmation, an unreadable program naming nothing is a
+        # Tuesday.
+        hidden_gated_verb = any(s.verb_unresolved and s.exe in _GATED_EXES for s in segs)
         blind_spot_reason: str | None = None
         if (
             not (push_segs or merge_pr_segs or merge_git_segs or create_segs)
             and blind is not None
-            and _mentions_gated_op(cmd)
+            and (_mentions_gated_op(cmd) or hidden_gated_verb)
         ):
             if blind.bounds_induced:
                 # The DEPTH bound refuses outright, interactive or not, and the

--- a/scripts/hooks/protected_paths_guard.py
+++ b/scripts/hooks/protected_paths_guard.py
@@ -266,11 +266,31 @@ def main() -> int:
                 f"an rm command that {blind.cause}, so its real targets cannot be "
                 f"resolved. To proceed: {blind.hint}"
             )
-        # `untokenizable` keeps the pre-existing substring fallback, unchanged. It is
-        # not a bound this change introduced, and widening it here would newly refuse
-        # ordinary work under cover of a regression fix.
+        # The substring fallback ADDS to the precise scan below; it does not replace
+        # it, and the missing `else` here used to be a fail-open.
+        #
+        # The comment this replaces said the fallback was kept "unchanged" so as not
+        # to "newly refuse ordinary work". True of the fallback itself, and it missed
+        # what the early RETURN did: any non-bounds blind spot skipped the segment
+        # scan entirely, downgrading this guard to a test the comment 25 lines above
+        # already calls STRICTLY WEAKER — precisely on the ANCESTOR and GLOB shapes
+        # it lists, which a substring test structurally cannot see.
+        #
+        # That was latent while `untokenizable` was the only non-bounds cause. It
+        # stopped being latent when shell_parse gained a second one: MEASURED
+        # base-vs-branch through this guard, `<a command whose verb the shell
+        # builds> && rm -rf ~/genesis` — the PARENT of the protected production
+        # database — went BLOCK -> ALLOW, because the concealed verb raised a blind
+        # spot and the blind spot skipped the scan that catches an ancestor.
+        #
+        # Falling through is safe in the direction that matters: the scan can only
+        # ADD refusals, and it runs on segments that tokenized fine (the bounds
+        # branch above has already returned for the case where there are none).
+        # MEASURED over 129,179 real commands: 1,697 mention rm, 68 of those reach
+        # this branch at all, and 0 change verdict.
         reason = _legacy_substring_block(cmd, dirs, f"that {blind.cause}. To proceed: {blind.hint}")
-        return _block(reason) if reason else 0
+        if reason:
+            return _block(reason)
 
     cwd = payload.get("cwd") if isinstance(payload, dict) else None
     for seg in segs:

--- a/scripts/hooks/shell_parse.py
+++ b/scripts/hooks/shell_parse.py
@@ -1389,26 +1389,39 @@ def _strip_wrappers(argv: list[str]) -> list[str]:
 #: problem this module cannot otherwise see: :func:`untokenizable` answers "did the
 #: parse fail", and here the parse SUCCEEDS while resolving something else.
 #:
-#: An ALLOWLIST, deliberately, and stated as one because the polarity is the entire
-#: safety argument. The set below is not "the spellings we have thought of" — it is
-#: the two characters that OPEN a substitution in bash's word grammar (parameter,
-#: command, arithmetic, and every quoting form layered over them), so a word free of
-#: both is one shlex and bash agree on, whatever else it contains. Enumerating the
-#: spellings instead (which quoting form, which encoding) is a denylist, and a
-#: denylist on a safety boundary is a treadmill whose every miss is a hole: the
-#: residual this rule closes was itself the second such spelling found, after a
-#: docstring had already called the first one "the one residual".
+#: An ALLOWLIST over SUBSTITUTION, deliberately, and scoped in that word because
+#: the scope is the part that keeps being overstated. These two characters open a
+#: substitution in bash's word grammar — parameter, command, arithmetic, and every
+#: quoting form layered over them — so a word free of both is a word shlex and bash
+#: agree on AS FAR AS SUBSTITUTION GOES. Enumerating spellings instead (which
+#: quoting form, which encoding) would be a denylist, and a denylist on a safety
+#: boundary is a treadmill whose every miss is a hole.
 #:
-#: TWO OTHER EXPANSIONS ARE EXCLUDED, and neither is an oversight. TILDE expansion
-#: applies only at the start of a word and only up to the first ``/``, which is
-#: strictly ahead of the basename :func:`_basename` reads — ``~/venv/bin/python``
-#: is ``python`` under every value of HOME, so flagging it would cost the common
-#: shape and buy nothing. PATHNAME expansion (``*?[``) is a real residual rather
-#: than a safe one: a glob resolves against FILENAMES, so ``git pu*`` only becomes
-#: a verb if a file of that name exists in the working directory, and otherwise
-#: stays the literal word git rejects. Closing it means flagging every ordinary
-#: ``ls *.py``-shaped word in verb position for a hazard that needs a planted file
-#: as well, which is a worse trade than saying so here.
+#: THIS IS NOT THE COMPLETE SET OF WORD-GENERATING CONSTRUCTS, and saying otherwise
+#: is the specific mistake this file keeps repeating. #1686's docstring called a
+#: hex-encoded verb "the one residual" and was already wrong when written. An
+#: earlier revision of THIS comment claimed the two characters covered the class
+#: and was falsified in review by BRACE expansion, which generates words without
+#: either of them. So the honest statement is the constructs COVERED, each named,
+#: and the ones deliberately left, each with its reason:
+#:
+#:   COVERED  substitution        here, via these two characters
+#:   COVERED  brace expansion     :func:`_has_brace_expansion` — ``{a,b}``, ``{a..b}``
+#:   LEFT     tilde expansion     applies only at the start of a word and only up to
+#:                                the first ``/``, which is strictly ahead of the
+#:                                basename :func:`_basename` reads. ``~/venv/bin/python``
+#:                                is ``python`` under every value of HOME, so flagging
+#:                                it would cost the common shape and buy nothing.
+#:   LEFT     pathname expansion  (``*?[``) a REAL residual, not a safe one. A glob
+#:                                resolves against FILENAMES, so ``git pu*`` becomes a
+#:                                verb only if a file of that name already exists in the
+#:                                working directory, and otherwise stays the literal word
+#:                                git rejects. Closing it means flagging every ordinary
+#:                                ``ls *.py``-shaped word in verb position for a hazard
+#:                                that also needs a planted file.
+#:
+#: A construct absent from both columns is UNEXAMINED, not covered. Add it to a
+#: column rather than assuming the columns are exhaustive.
 _EXPANSION_MARKS = ("$", "`")
 
 #: Programs whose FIRST WORDS choose the operation, so the verb is not argv[0].
@@ -1429,9 +1442,66 @@ _VERB_DISPATCHERS: dict[str, tuple[frozenset[str], frozenset[str]]] = {
 }
 
 
+def _has_brace_expansion(token: str) -> bool:
+    """Whether *token* carries a bash BRACE EXPANSION — ``{a,b}`` or ``{a..b}``.
+
+    Brace expansion generates words with no substitution character anywhere, so it
+    is invisible to :data:`_EXPANSION_MARKS` and needed its own check. shlex keeps
+    the braces verbatim, which is one more way a token can tokenize cleanly into
+    something bash never runs.
+
+    A brace group expands only when its top level holds a COMMA or a ``..`` range —
+    ``{a}`` and ``{}`` are literal to bash, and treating them as expansion would
+    flag ordinary text. Nesting is tracked so the comma of an INNER group does not
+    make an outer literal group look expandable, matching bash, which expands
+    ``{{a,b}}`` via the inner group.
+
+    THE RANGE FORM IS WHY THIS IS A RULE AND NOT A FOOTNOTE. A comma list always
+    emits at least two words, so it lands an extra argument next to the verb and
+    corrupts the rest of argv — real, but self-limiting. A range with identical
+    endpoints emits exactly ONE word: ``pus{h..h}`` is a single ``push``, argv
+    intact. VERIFIED against bash itself through a shim that prints its own argv,
+    rather than reasoned about — the two forms look alike and behave differently,
+    and the difference is the whole severity of the case.
+    """
+    i, n = 0, len(token)
+    while i < n:
+        if token[i] != "{":
+            i += 1
+            continue
+        depth = 1
+        expandable = False
+        j = i + 1
+        while j < n:
+            c = token[j]
+            if c == "{":
+                depth += 1
+            elif c == "}":
+                depth -= 1
+                if depth == 0:
+                    break
+            elif depth == 1:
+                if c == ",":
+                    expandable = True
+                elif c == "." and j + 1 < n and token[j + 1] == ".":
+                    expandable = True
+                    j += 1
+            j += 1
+        if j < n and depth == 0 and expandable:
+            return True
+        i += 1  # unterminated or literal group — bash leaves it alone, so do we
+    return False
+
+
 def _word_is_literal(token: str) -> bool:
-    """Whether *token* means, to bash, exactly the characters it spells."""
-    return not any(mark in token for mark in _EXPANSION_MARKS)
+    """Whether *token* means, to bash, exactly the characters it spells.
+
+    Covers the constructs named beside :data:`_EXPANSION_MARKS`, and only those.
+    Tilde and pathname expansion are deliberately out, with reasons recorded there.
+    """
+    if any(mark in token for mark in _EXPANSION_MARKS):
+        return False
+    return not _has_brace_expansion(token)
 
 
 def _word_continues(token: str) -> bool:

--- a/scripts/hooks/shell_parse.py
+++ b/scripts/hooks/shell_parse.py
@@ -1463,34 +1463,65 @@ def _has_brace_expansion(token: str) -> bool:
     intact. VERIFIED against bash itself through a shim that prints its own argv,
     rather than reasoned about — the two forms look alike and behave differently,
     and the difference is the whole severity of the case.
+
+    ONE LEFT-TO-RIGHT PASS, and that is a security property rather than a matter of
+    taste. The first version of this scan restarted an inner walk at every ``{``,
+    so a token of unterminated openers cost O(n^2): MEASURED on this function,
+    0.014s at 500 characters, 5.5s at 8,000, and 173s at
+    :data:`MAX_COMMAND_CHARS` — against guards registered with a 10-second wall
+    clock. The hook contract is explicit that a timed-out hook does not block the
+    tool call, so a guard that runs out of clock PERMITS, and this module feeds
+    nine of them: one crafted word would have disengaged the lot. A stack of
+    per-group flags answers the same question without ever re-reading a character,
+    because a ``{`` already passed can only ever be the group the next ``}``
+    closes.
+
+    The stack entry is that group's own "saw a top-level comma or range" flag, so
+    the innermost open group is the one a separator belongs to — which is exactly
+    the nesting rule above, expressed without a second traversal.
     """
+    stack: list[bool] = []
     i, n = 0, len(token)
     while i < n:
-        if token[i] != "{":
-            i += 1
-            continue
-        depth = 1
-        expandable = False
-        j = i + 1
-        while j < n:
-            c = token[j]
-            if c == "{":
-                depth += 1
-            elif c == "}":
-                depth -= 1
-                if depth == 0:
-                    break
-            elif depth == 1:
-                if c == ",":
-                    expandable = True
-                elif c == "." and j + 1 < n and token[j + 1] == ".":
-                    expandable = True
-                    j += 1
-            j += 1
-        if j < n and depth == 0 and expandable:
-            return True
-        i += 1  # unterminated or literal group — bash leaves it alone, so do we
-    return False
+        c = token[i]
+        if c == "{":
+            stack.append(False)
+        elif c == "}":
+            if stack and stack.pop():
+                return True  # this group expands, so the whole word does
+        elif stack:  # a separator belongs to the INNERMOST open group
+            if c == ",":
+                stack[-1] = True
+            elif c == "." and i + 1 < n and token[i + 1] == ".":
+                stack[-1] = True
+                i += 1
+        i += 1
+    return False  # openers never closed — bash leaves them alone, so do we
+
+
+#: Longest verb-position WORD this module will read before giving up on it.
+#:
+#: A second line of defence, not the primary one: the scans this bounds are all
+#: linear now, and a linear pass over even a :data:`MAX_COMMAND_CHARS` word costs
+#: microseconds. It exists because the primary defence is "every scanner here stays
+#: linear", which is an invariant a future edit can break silently — and the way it
+#: broke once already was a nested loop that looked perfectly ordinary. A bound
+#: cannot be forgotten the way a complexity argument can.
+#:
+#: FAILS CLOSED, which is the whole point of putting it here rather than making it
+#: a truncation. An over-long word is one this module has declined to establish, and
+#: this PR's own principle is that a verb it cannot establish is unestablished
+#: rather than absent — so :func:`_word_is_literal` says "not literal" and the word
+#: routes to the blind-spot net. Truncating and judging the prefix would be the
+#: opposite: a confident answer about a word nobody read.
+#:
+#: DERIVED, not chosen. MEASURED over 129,179 real commands from this install's
+#: transcripts, the longest word ever reaching :func:`_word_is_literal` is 3,176
+#: characters (a line of prose inside a here-doc body, not a verb anyone typed);
+#: 481 words exceed 1,024. The cap sits above the observed maximum with headroom,
+#: so it costs zero flips on observed traffic — verified in the same two-stage
+#: measurement as the rest of this change.
+_MAX_VERB_WORD_CHARS = 4096
 
 
 def _word_is_literal(token: str) -> bool:
@@ -1498,7 +1529,13 @@ def _word_is_literal(token: str) -> bool:
 
     Covers the constructs named beside :data:`_EXPANSION_MARKS`, and only those.
     Tilde and pathname expansion are deliberately out, with reasons recorded there.
+
+    An over-long word is NOT literal — see :data:`_MAX_VERB_WORD_CHARS`. That is
+    the fail-closed direction: this module declined to read the word, and declining
+    to read is not evidence that the word is harmless.
     """
+    if len(token) > _MAX_VERB_WORD_CHARS:
+        return False
     if any(mark in token for mark in _EXPANSION_MARKS):
         return False
     return not _has_brace_expansion(token)

--- a/scripts/hooks/shell_parse.py
+++ b/scripts/hooks/shell_parse.py
@@ -1411,10 +1411,12 @@ def _strip_wrappers(argv: list[str]) -> list[str]:
 #:   COVERED  brace expansion     in verb position, via :func:`_has_brace_expansion`
 #:                                — ``{a,b}``, ``{a..b}``
 #:   LEFT     ANY expansion in a  A value-taking option's value is skipped unread
-#:            VALUE slot          (see :func:`_verb_unresolved`), so an expansion
-#:                                there can INJECT a verb the parse never sees —
-#:                                ``git -C <expansion producing "x <verb>"> …`` runs
-#:                                the verb with argv intact. PRE-EXISTING and not
+#:            VALUE slot          (see :func:`_verb_unresolved`), in BOTH the split
+#:            (either option      (``-C <v>``) and attached (``--git-dir=<v>``)
+#:             form)              forms — they are one command to bash and answer
+#:                                the same here. So an expansion there can INJECT a
+#:                                verb the parse never sees, with argv intact.
+#:                                PRE-EXISTING and not
 #:                                made worse here: measured base-vs-branch, these
 #:                                shapes are ALLOW on both. Left because the price is
 #:                                the wrong shape — MEASURED over 129,179 real
@@ -1427,6 +1429,14 @@ def _strip_wrappers(argv: list[str]) -> list[str]:
 #:                                corpus exercises. `_word_continues` covers only the
 #:                                narrow sub-case where the value is the unterminated
 #:                                HEAD of a split word.
+#:                                RE-MEASURED from the GRAMMAR rather than the corpus
+#:                                after a corpus null result was wrong three times:
+#:                                384 generated cells over program x option form x
+#:                                construct x position, each evaluated under four
+#:                                environments so a slot that CAN move the verb is
+#:                                identified by watching it move rather than by
+#:                                argument. This slot moves; every other new refusal
+#:                                sits on a slot that also moves.
 #:   LEFT     tilde expansion     applies only at the start of a word and only up to
 #:                                the first ``/``, which is strictly ahead of the
 #:                                basename :func:`_basename` reads. ``~/venv/bin/python``
@@ -1651,20 +1661,32 @@ def _verb_unresolved(argv: list[str]) -> bool:
     i = 1
     while i < len(argv):
         tok = argv[i]
-        if not _word_is_literal(tok):
-            return True  # the verb itself, or an option that decides where it sits
-        if tok in value_flags:
-            # The value is not verb position, so it is skipped unread — UNLESS it is
-            # only the head of a split word, in which case skipping it lands the walk
-            # on that word's tail and every position after is wrong. See
-            # :func:`_word_continues`.
-            if i + 1 < len(argv) and _word_continues(argv[i + 1]):
-                return True
-            i += 2
-            continue
         if tok.startswith("-"):
+            # AN OPTION. Only its NAME can decide where the verb sits, so only the
+            # NAME is read. An ATTACHED value (``--git-dir=<value>``) rides inside
+            # the same shlex token, and testing the whole token reads a VALUE as
+            # though it were a verb — which made an ordinary ``git --git-dir=$DIR
+            # status`` ask for approval while the identical SPLIT form did not. The
+            # two forms are the same command to bash, so they answer the same here.
+            #
+            # An unreadable option NAME still returns True: it can expand to a
+            # value-taking flag and consume the following word, which shifts what
+            # lands in the verb slot.
+            if not _word_is_literal(tok.split("=", 1)[0]) or _word_continues(tok):
+                return True
+            if "=" not in tok and tok in value_flags:
+                # The SEPARATE form: the value is the next token, skipped unread for
+                # the same reason an attached one is — UNLESS it is only the head of
+                # a split word, in which case skipping it lands the walk on that
+                # word's tail and every position after is wrong (:func:`_word_continues`).
+                if i + 1 < len(argv) and _word_continues(argv[i + 1]):
+                    return True
+                i += 2
+                continue
             i += 1
             continue
+        if not _word_is_literal(tok):
+            return True  # the verb itself
         if tok in groups:
             groups = frozenset()  # a group name: the NEXT bare word is the verb
             i += 1

--- a/scripts/hooks/shell_parse.py
+++ b/scripts/hooks/shell_parse.py
@@ -32,6 +32,18 @@ at its own boundary — the parser degrades gracefully, each gate decides for
 itself what an unverifiable command means. Callers must probe the RAW command:
 normalizing text before a blind-spot probe can only ever delete the evidence
 the probe looks for.
+
+There is a SECOND blind spot, and it does not look like one, which is why it
+needed its own rule. ``untokenizable`` answers "did the parse fail". It cannot
+answer "did the parse succeed at the wrong thing" — and shlex, which implements
+no shell expansion at all, resolves a word that carries one into a token bash
+would never run. When such a word sits in VERB POSITION, the module returns a
+clean parse naming an operation nobody asked for, and every gate searching for a
+real operation finds none. :func:`_verb_unresolved` marks those segments, and
+:func:`analyze_checked` reports the half of them whose cost was measured and
+found affordable, so a verb the parser cannot ESTABLISH is treated as
+unestablished rather than as absent. The other half, and the number that decided
+it, are written out beside :data:`_BLIND_UNRESOLVED_VERB`.
 """
 
 from __future__ import annotations
@@ -134,6 +146,11 @@ class Segment:
     redirects: list[str] = field(
         default_factory=list
     )  # expansion redirect targets excised from argv
+    #: The words choosing WHICH operation this segment runs carry a shell
+    #: expansion, so ``exe``/``argv`` name something other than what bash runs.
+    #: See :func:`_verb_unresolved`. A guard must not read a False verdict off
+    #: this segment's verb; :func:`analyze_checked` reports it as a blind spot.
+    verb_unresolved: bool = False
 
 
 def _redirect_operator_len(command: str, i: int) -> int | None:
@@ -1024,6 +1041,15 @@ class BlindSpot(NamedTuple):
     tokenization failed", and a consumer that forgot it kept the old behaviour with
     no signal. Removing it makes every stale comparison an AttributeError at test
     time — loud, at the one moment a silent fail-open is affordable to catch.
+
+    AND :data:`_BLIND_UNRESOLVED_VERB` DID NOT GET ONE EITHER. It looked as though
+    it needed a field: one guard must treat that cause differently, because its
+    engage-test is the operation's NAME in the raw text and this is the one cause
+    that removes the name. A field here would have made every consumer choose
+    again, silently, which is the generator this class already paid for once. The
+    fact lives on :attr:`Segment.verb_unresolved` instead, and the guard that needs
+    it reads that against its OWN list of gated programs. Which programs are gated
+    is the guard's to say; why the parse is blind is ours.
     """
 
     cause: str
@@ -1070,6 +1096,63 @@ _BLIND_OVER_LONG = BlindSpot(
     ),
 )
 
+#: The parse SUCCEEDED and resolved a verb that is not the one bash runs. That is a
+#: different failure from the other three, and worse than any of them: the others
+#: leave the caller with nothing, this one leaves it with a confident wrong answer.
+#: A gate reading it sees "no gated operation" and cannot tell that reading apart
+#: from a command that genuinely has none.
+#:
+#: ``bounds_induced`` is False, and the reason is the same one it is False for
+#: :data:`_BLIND_UNTOKENIZABLE`: that flag means "a bound cut this parse short", and
+#: no bound fired here. The consumers that key on it exist to restore what a bound
+#: took away, so claiming a bound to reach them would be a hard block wearing the
+#: costume of a bounds regression — the exact substitution the ``refuse`` flag was
+#: removed for. Consumers that ask a broader question (``blind is not None``) net
+#: this cause as they net any other, which is an ASK where a human is present.
+_BLIND_UNRESOLVED_VERB = BlindSpot(
+    bounds_induced=False,
+    cause=(
+        "picks the operation it performs with a name the shell builds rather than "
+        "one written out, so the guard cannot establish which operation that is"
+    ),
+    hint=(
+        "write the subcommand out literally — a variable or a substitution belongs "
+        "in an argument, where it does not decide which operation runs"
+    ),
+)
+
+#: THE OTHER HALF OF VERB POSITION IS DELIBERATELY NOT REPORTED, and the reason is
+#: measurement rather than oversight. When the PROGRAM ITSELF is built by the shell
+#: (``$PY x.py``, ``$SSH host …``), nothing about the segment is established — not
+#: the operation, not even which executable performs it. :attr:`Segment.verb_unresolved`
+#: records it, because it is true; :func:`analyze_checked` stays quiet about it,
+#: because reporting it does not pay.
+#:
+#: MEASURED end to end — parse diff over 129,179 unique real commands harvested from
+#: this install's transcripts, then the actual guards run over every candidate in
+#: both trees, counting VERDICT changes rather than parse changes:
+#:
+#:     dispatcher verb unreadable   14 commands   13 push + 10 commit allow->ask
+#:     program name unreadable   1,845 commands  203 push + 206 commit allow->ask,
+#:                                                 5 path blocks, and ONE block->allow
+#:
+#: The last cell is the decisive one. `protected_paths_guard` answers a non-bounds
+#: blind spot by REPLACING its precise segment scan with a substring fallback that
+#: its own comment calls strictly weaker — so a newly-reported blind spot on a
+#: command it used to refuse turned that refusal into an allow. That is a defect in
+#: the guard rather than in this rule (any new non-bounds cause trips it, and it is
+#: filed separately), but it means reporting a cause with this volume moves verdicts
+#: in the fail-open direction, which is not a trade a security fix gets to make. The
+#: 200-odd extra prompts alone would also put the change an order of magnitude past
+#: the cost the narrow rule pays.
+#:
+#: The residual that leaves, stated so it is not mistaken for coverage: a command
+#: that names its program with a variable is read exactly as it is today, whether or
+#: not it spells the operation. Closing it needs a way to tell such a command apart
+#: from the 1,845 — an interpreter or a remote shell held in a variable is ordinary
+#: work here — which this rule does not have, and guessing at one is how a net
+#: becomes an outage.
+
 #: Every blind spot this module can report. Exported so a test can enforce the
 #: invariant `refuse ⟹ bounds_induced` over the WHOLE domain rather than over the
 #: examples a test author happened to think of.
@@ -1079,7 +1162,12 @@ _BLIND_OVER_LONG = BlindSpot(
 #: which the hook contract reads as NON-BLOCKING, so the invariant check would itself
 #: become a fail-open. The enforcement point for an invariant is a test, which fails
 #: loudly at the one moment nothing is at stake.
-_ALL_BLIND_SPOTS = (_BLIND_UNTOKENIZABLE, _BLIND_OVER_NESTED, _BLIND_OVER_LONG)
+_ALL_BLIND_SPOTS = (
+    _BLIND_UNTOKENIZABLE,
+    _BLIND_OVER_NESTED,
+    _BLIND_OVER_LONG,
+    _BLIND_UNRESOLVED_VERB,
+)
 
 
 def over_nested(command: str) -> bool:
@@ -1159,6 +1247,14 @@ def analyze_checked(command: str) -> tuple[list[Segment], BlindSpot | None]:
     command flipped three guards from BLOCK to ALLOW, because an apostrophe in a
     comment is valid shell that shlex cannot tokenize. Reversing the order costs
     2 of 45,956 real commands a reclassification and no change of verdict.
+
+    :data:`_BLIND_UNRESOLVED_VERB` is reported LAST, which means it is reported only
+    where this function previously returned None. That is a property worth stating
+    rather than a rank: every command that already had a blind spot keeps the exact
+    cause and hint it had, so the rule can only add net coverage and can never
+    reword or re-rank an existing refusal. It also makes the change measurable — the
+    flips it causes are exactly the commands moving from "clean parse" to "blind",
+    with nothing else shifting underneath them.
     """
     segments, reason = _analyze_bounded(command)
     if reason == "length":
@@ -1167,6 +1263,8 @@ def analyze_checked(command: str) -> tuple[list[Segment], BlindSpot | None]:
         return [], _BLIND_OVER_NESTED
     if untokenizable(command):
         return segments, _BLIND_UNTOKENIZABLE
+    if any(_dispatcher_verb_unresolved(s) for s in segments):
+        return segments, _BLIND_UNRESOLVED_VERB
     return segments, None
 
 
@@ -1284,6 +1382,123 @@ def _strip_wrappers(argv: list[str]) -> list[str]:
     return result
 
 
+#: Characters that make a shell WORD mean something other than what it spells.
+#: shlex implements quote removal and backslash escapes faithfully and implements
+#: NO expansion whatsoever, so a word carrying one of these tokenizes CLEANLY into
+#: a token that is not the word bash finally runs. That is the whole shape of the
+#: problem this module cannot otherwise see: :func:`untokenizable` answers "did the
+#: parse fail", and here the parse SUCCEEDS while resolving something else.
+#:
+#: An ALLOWLIST, deliberately, and stated as one because the polarity is the entire
+#: safety argument. The set below is not "the spellings we have thought of" — it is
+#: the two characters that OPEN a substitution in bash's word grammar (parameter,
+#: command, arithmetic, and every quoting form layered over them), so a word free of
+#: both is one shlex and bash agree on, whatever else it contains. Enumerating the
+#: spellings instead (which quoting form, which encoding) is a denylist, and a
+#: denylist on a safety boundary is a treadmill whose every miss is a hole: the
+#: residual this rule closes was itself the second such spelling found, after a
+#: docstring had already called the first one "the one residual".
+#:
+#: TWO OTHER EXPANSIONS ARE EXCLUDED, and neither is an oversight. TILDE expansion
+#: applies only at the start of a word and only up to the first ``/``, which is
+#: strictly ahead of the basename :func:`_basename` reads — ``~/venv/bin/python``
+#: is ``python`` under every value of HOME, so flagging it would cost the common
+#: shape and buy nothing. PATHNAME expansion (``*?[``) is a real residual rather
+#: than a safe one: a glob resolves against FILENAMES, so ``git pu*`` only becomes
+#: a verb if a file of that name exists in the working directory, and otherwise
+#: stays the literal word git rejects. Closing it means flagging every ordinary
+#: ``ls *.py``-shaped word in verb position for a hazard that needs a planted file
+#: as well, which is a worse trade than saying so here.
+_EXPANSION_MARKS = ("$", "`")
+
+#: Programs whose FIRST WORDS choose the operation, so the verb is not argv[0].
+#: Per exe: (global options that consume the FOLLOWING token as a value, the
+#: first-words that dispatch a FURTHER verb). ``git push`` is one word; ``gh pr
+#: merge`` is two, because ``pr`` is a group rather than an operation.
+#:
+#: MIRRORS THE CONSUMERS — :func:`git_subcommand` and :func:`gh_pr_subcommand` —
+#: rather than modelling each CLI's grammar, and the difference is not cosmetic. A
+#: generic "the verb is the first N bare words" rule reads one word too far for
+#: every gh command that is not ``gh pr``: MEASURED over 129,179 real commands, it
+#: flagged 1,830 ``gh api <endpoint>`` invocations, whose endpoint is an ARGUMENT
+#: that routinely interpolates an issue number or a sha. A verb rule that reads an
+#: argument is not a stricter verb rule, it is a different and wrong one.
+_VERB_DISPATCHERS: dict[str, tuple[frozenset[str], frozenset[str]]] = {
+    "git": (frozenset(_GIT_OPTS_WITH_ARG), frozenset()),
+    "gh": (frozenset({"-R", "--repo"}), frozenset({"pr"})),
+}
+
+
+def _word_is_literal(token: str) -> bool:
+    """Whether *token* means, to bash, exactly the characters it spells."""
+    return not any(mark in token for mark in _EXPANSION_MARKS)
+
+
+def _verb_unresolved(argv: list[str]) -> bool:
+    """Whether this argv's VERB — the words that decide WHICH operation runs —
+    carries a shell expansion, so the parse cannot establish what it is.
+
+    Two positions qualify, and only these two:
+
+    * the executable's BASENAME. Only the basename, because that is what
+      :func:`_basename` reads and what a gate compares: ``$HOME/bin/git`` and
+      ``~/venv/bin/python`` resolve to ``git`` and ``python`` no matter what the
+      leading component expands to, so flagging them would be a pure over-block
+      with no hazard behind it. ``/usr/bin/$X`` does NOT resolve, and is flagged.
+    * for a multi-verb dispatcher, the words that select the subcommand — plus any
+      option word passed on the way to it, because an unreadable option can shift
+      which word lands in the verb slot.
+
+    An ARGUMENT is deliberately out of scope. ``git commit -m "$msg"``,
+    ``rm "$f"``, ``echo $PATH`` are ordinary work; a gate that asked about every
+    variable in every argument would be turned off within a week, and the failure
+    this closes is specifically that the OPERATION is unestablished while the
+    parse reports success. What an unresolved argument costs a path or flag gate
+    is a different question with a different answer, and is not answered here.
+
+    Returns False for an empty argv — nothing executes, so there is no verb.
+    """
+    if not argv:
+        return False
+    if not _word_is_literal(_basename(argv[0])):
+        return True
+    spec = _VERB_DISPATCHERS.get(_basename(argv[0]))
+    if spec is None:
+        return False
+    value_flags, groups = spec
+    i = 1
+    while i < len(argv):
+        tok = argv[i]
+        if not _word_is_literal(tok):
+            return True  # the verb itself, or an option that decides where it sits
+        if tok in value_flags:
+            i += 2  # the value is not verb position — skip it unread
+            continue
+        if tok.startswith("-"):
+            i += 1
+            continue
+        if tok in groups:
+            groups = frozenset()  # a group name: the NEXT bare word is the verb
+            i += 1
+            continue
+        return False  # the verb, read plainly
+    return False  # ran out of words before the verb was complete — nothing to hide
+
+
+def _dispatcher_verb_unresolved(seg: Segment) -> bool:
+    """The narrower half of :attr:`Segment.verb_unresolved`: the PROGRAM resolved,
+    and it is one whose first words select the operation — but those words did not.
+
+    This is the half a guard may act on WITHOUT first looking for the operation's
+    name in the raw text, because here that name is exactly what is missing. The
+    other half — the program itself unreadable — is recorded on the Segment and
+    deliberately NOT reported as a blind spot; the measurement that decided that,
+    and the residual it leaves, are written out beside
+    :data:`_BLIND_UNRESOLVED_VERB`.
+    """
+    return bool(seg.verb_unresolved and seg.argv and _basename(seg.argv[0]) in _VERB_DISPATCHERS)
+
+
 def analyze(command: str) -> list[Segment]:
     """Parse a Bash command into executed Segments (nested scripts flattened).
 
@@ -1352,7 +1567,14 @@ def _analyze_bounded(command: str, *, _depth: int = 0) -> tuple[list[Segment], s
         argv = _strip_wrappers(_argv(seg.argv_src))
         exe = _basename(argv[0]) if argv else ""
         out.append(
-            Segment(exe=exe, argv=argv, override=override, raw=raw, redirects=list(seg.redirects))
+            Segment(
+                exe=exe,
+                argv=argv,
+                override=override,
+                raw=raw,
+                redirects=list(seg.redirects),
+                verb_unresolved=_verb_unresolved(argv),
+            )
         )
         nested = []
         if exe in _NESTED:
@@ -1386,6 +1608,7 @@ def _analyze_bounded(command: str, *, _depth: int = 0) -> tuple[list[Segment], s
                         raw=inner.raw,
                         depth=inner.depth + 1,
                         redirects=inner.redirects,
+                        verb_unresolved=inner.verb_unresolved,
                     )
                 )
     return out, ("depth" if truncated else None)

--- a/scripts/hooks/shell_parse.py
+++ b/scripts/hooks/shell_parse.py
@@ -1434,6 +1434,45 @@ def _word_is_literal(token: str) -> bool:
     return not any(mark in token for mark in _EXPANSION_MARKS)
 
 
+def _word_continues(token: str) -> bool:
+    """Whether *token* is only PART of a bash word, so the next tokens are its tail.
+
+    An UNQUOTED ``$( … )`` containing a space is ONE word to bash and SEVERAL tokens
+    to shlex, which splits on that space like any other. Every position after it is
+    then off by however many tokens the substitution contributed — so a walk that
+    counts positions is reading a different word than bash will.
+
+    This matters at exactly one place: the token a value-taking option consumes.
+    Everywhere else the walk already inspects the token itself, and a partial
+    substitution carries the ``$`` or the backtick that :func:`_word_is_literal`
+    catches. The consumed value is the one token skipped unread — and skipping the
+    HEAD of a split word leaves the walk pointing at that word's TAIL, which can be
+    an ordinary-looking literal with the real verb sitting behind it.
+
+    Detects an unterminated ``$(`` and an odd backtick count. Deliberately ignores
+    parentheses NOT opened by ``$`` — ``--format=%(refname)`` is data, and treating
+    its parens as syntax is how a rule like this starts flagging ordinary work.
+    MEASURED over 129,179 real commands: this adds ZERO flags on top of the verb
+    rule, so it closes the position-shift case at no cost at all.
+    """
+    depth = 0
+    saw_sub = False
+    i, n = 0, len(token)
+    while i < n:
+        if token[i] == "$" and i + 1 < n and token[i + 1] == "(":
+            depth += 1
+            saw_sub = True
+            i += 2
+            continue
+        if depth:
+            if token[i] == "(":
+                depth += 1
+            elif token[i] == ")":
+                depth -= 1
+        i += 1
+    return (saw_sub and depth > 0) or token.count("`") % 2 == 1
+
+
 def _verb_unresolved(argv: list[str]) -> bool:
     """Whether this argv's VERB — the words that decide WHICH operation runs —
     carries a shell expansion, so the parse cannot establish what it is.
@@ -1447,7 +1486,9 @@ def _verb_unresolved(argv: list[str]) -> bool:
       with no hazard behind it. ``/usr/bin/$X`` does NOT resolve, and is flagged.
     * for a multi-verb dispatcher, the words that select the subcommand — plus any
       option word passed on the way to it, because an unreadable option can shift
-      which word lands in the verb slot.
+      which word lands in the verb slot, and plus the VALUE of a value-taking
+      option when that value is only the head of a split word (see
+      :func:`_word_continues`), for the same reason one step removed.
 
     An ARGUMENT is deliberately out of scope. ``git commit -m "$msg"``,
     ``rm "$f"``, ``echo $PATH`` are ordinary work; a gate that asked about every
@@ -1472,7 +1513,13 @@ def _verb_unresolved(argv: list[str]) -> bool:
         if not _word_is_literal(tok):
             return True  # the verb itself, or an option that decides where it sits
         if tok in value_flags:
-            i += 2  # the value is not verb position — skip it unread
+            # The value is not verb position, so it is skipped unread — UNLESS it is
+            # only the head of a split word, in which case skipping it lands the walk
+            # on that word's tail and every position after is wrong. See
+            # :func:`_word_continues`.
+            if i + 1 < len(argv) and _word_continues(argv[i + 1]):
+                return True
+            i += 2
             continue
         if tok.startswith("-"):
             i += 1

--- a/scripts/hooks/shell_parse.py
+++ b/scripts/hooks/shell_parse.py
@@ -1402,11 +1402,31 @@ def _strip_wrappers(argv: list[str]) -> list[str]:
 #: hex-encoded verb "the one residual" and was already wrong when written. An
 #: earlier revision of THIS comment claimed the two characters covered the class
 #: and was falsified in review by BRACE expansion, which generates words without
-#: either of them. So the honest statement is the constructs COVERED, each named,
-#: and the ones deliberately left, each with its reason:
+#: either of them. A LATER revision then listed brace expansion as COVERED without
+#: qualification, and was falsified the same way: it is covered in VERB POSITION,
+#: and a brace group in an option's VALUE slot is a different, open case. Twice is
+#: a pattern, so the columns below name a POSITION as well as a construct.
 #:
-#:   COVERED  substitution        here, via these two characters
-#:   COVERED  brace expansion     :func:`_has_brace_expansion` — ``{a,b}``, ``{a..b}``
+#:   COVERED  substitution        in verb position, via these two characters
+#:   COVERED  brace expansion     in verb position, via :func:`_has_brace_expansion`
+#:                                — ``{a,b}``, ``{a..b}``
+#:   LEFT     ANY expansion in a  A value-taking option's value is skipped unread
+#:            VALUE slot          (see :func:`_verb_unresolved`), so an expansion
+#:                                there can INJECT a verb the parse never sees —
+#:                                ``git -C <expansion producing "x <verb>"> …`` runs
+#:                                the verb with argv intact. PRE-EXISTING and not
+#:                                made worse here: measured base-vs-branch, these
+#:                                shapes are ALLOW on both. Left because the price is
+#:                                the wrong shape — MEASURED over 129,179 real
+#:                                commands, flagging a non-literal value slot fires on
+#:                                711 of them (0.55%, 0.44% of invocations), against
+#:                                15 for everything this module currently moves. The
+#:                                dominant shape is ``git -C $WT`` on a worktree path,
+#:                                which is ordinary work here, so closing it would
+#:                                trade a 47x over-block for a residual nothing in the
+#:                                corpus exercises. `_word_continues` covers only the
+#:                                narrow sub-case where the value is the unterminated
+#:                                HEAD of a split word.
 #:   LEFT     tilde expansion     applies only at the start of a word and only up to
 #:                                the first ``/``, which is strictly ahead of the
 #:                                basename :func:`_basename` reads. ``~/venv/bin/python``
@@ -1560,7 +1580,21 @@ def _word_continues(token: str) -> bool:
     parentheses NOT opened by ``$`` — ``--format=%(refname)`` is data, and treating
     its parens as syntax is how a rule like this starts flagging ordinary work.
     MEASURED over 129,179 real commands: this adds ZERO flags on top of the verb
-    rule, so it closes the position-shift case at no cost at all.
+    rule.
+
+    WHAT IT CLOSES, stated narrowly because a wider claim was wrong. It closes the
+    case where the skipped value is the unterminated HEAD of a split word — nothing
+    more. It does NOT close "the position-shift case" in general, which an earlier
+    revision of this docstring claimed: a value that is a plain ``$VAR`` or a brace
+    group is a single, terminated token, so neither test here fires, and the walk
+    skips it and runs out of words. A value that EXPANDS to several words then
+    injects a verb the parse never sees at all. That is the LEFT-column entry beside
+    :data:`_EXPANSION_MARKS`, it is PRE-EXISTING rather than introduced here, and the
+    711-command price of closing it is recorded there.
+
+    Zero added flags is therefore not evidence of coverage. It is what a narrow test
+    costs, and the two facts are easy to confuse — which is how the wider claim got
+    written next to the smaller number in the first place.
     """
     depth = 0
     saw_sub = False

--- a/scripts/hooks/worktree_cwd_guard.py
+++ b/scripts/hooks/worktree_cwd_guard.py
@@ -326,7 +326,25 @@ def _handle_bash(data: dict) -> int:
     # that already fail closed here. The legacy regex extractor is the same
     # coarser reading the untokenizable case falls back to: weaker than the
     # parser, but it reads the raw text, so a bound cannot hide anything from it.
-    if untokenizable(cmd) or blind is not None:
+    # `blind.bounds_induced`, NOT `blind is not None`, and the comment above says
+    # why without meaning to: it justifies this fallback with "a BOUND stopped the
+    # parse — and `analyze_checked` then returns NO segments". That is the whole
+    # argument, and it is true of the BOUNDS causes only. A cause that leaves the
+    # segments COMPLETE — the parse succeeded, one word of it is unreadable — hands
+    # this branch a full segment list and then throws it away for a quote-blind
+    # regex over the raw text.
+    #
+    # MEASURED base-vs-branch when this read `blind is not None`: a `gh pr` whose
+    # verb was a variable, with a --body whose PROSE mentions removing a worktree,
+    # went ALLOW -> hard BLOCK. Writing a PR body about worktree removal is
+    # something sessions do constantly — this one's own body does it — and a hard
+    # block on prose is the worst direction available to this guard.
+    #
+    # `untokenizable` keeps the fallback unchanged: there the tokens really are
+    # unreliable. The parsed route below has its own carrier fallback for a removal
+    # the parser cannot see, so declining to degrade here is not the same as
+    # trusting the parse blindly.
+    if untokenizable(cmd) or (blind is not None and blind.bounds_induced):
         targets = _legacy_targets(cmd)
     else:
         targets = _extract_worktree_targets(segs)

--- a/tests/test_hooks/test_guard_ansic_fail_closed.py
+++ b/tests/test_hooks/test_guard_ansic_fail_closed.py
@@ -1093,6 +1093,15 @@ _BENIGN_EXPANSIONS = [
     # with a green test. The reasoning and the price are beside
     # `shell_parse._EXPANSION_MARKS`, in its LEFT column.
     ("dash_C_value", f"{GIT} -C $DIR status"),
+    # ATTACHED option values. shlex yields `--git-dir=$DIR` as ONE token, so a
+    # rule that tests the whole token reads the VALUE as though it were a verb.
+    # MEASURED: this asked for approval while the identical SPLIT form did not —
+    # and an ask is a BLOCK in a dispatched session, where nobody can answer, on
+    # a completely ordinary command. Same shape for --work-tree=, --namespace=
+    # and gh's --repo=.
+    ("attached_git_dir", f"{GIT} --git-dir=$DIR status"),
+    ("attached_work_tree", f"{GIT} --work-tree=$W status"),
+    ("attached_gh_repo", "gh --repo=$R pr view 1"),
     ("gh_api_endpoint", "gh api repos/o/r/issues/$n/comments --jq .[].body"),
     ("tilde_exe_path", "~/venv/bin/python -m pytest tests/x.py"),
     ("variable_exe_dir", "$VENV/bin/python -m pytest tests/x.py"),
@@ -1260,6 +1269,36 @@ class TestVerbPositionReachesTheGuard:
         cmd = f'{GIT} $"{PUSH}" origin main'
         r = _run(_PUSH_GUARD, cmd, cwd=str(tmp_path), dispatched="1")
         assert _decision(r) == "block", r.stdout + r.stderr
+
+    @pytest.mark.parametrize(
+        "attached,split",
+        [
+            (f"{GIT} --git-dir=$D status", f"{GIT} --git-dir $D status"),
+            (f"{GIT} --work-tree=$D status", f"{GIT} --work-tree $D status"),
+            ("gh --repo=$R pr view 1", "gh --repo $R pr view 1"),
+        ],
+    )
+    def test_the_attached_and_split_option_forms_agree(self, attached, split, tmp_path):
+        """Two spellings of ONE command must not get two verdicts.
+
+        `--opt=value` and `--opt value` are the same command to bash. The first
+        version of the verb rule read the whole attached token, so the value
+        landed in the test meant for the verb and only that spelling asked.
+
+        Asserts EQUALITY rather than a fixed verdict, so this keeps meaning
+        something if the shared verdict ever legitimately changes — what must
+        never differ is the two forms.
+        """
+        a = _decision(_run(_PUSH_GUARD, attached, cwd=str(tmp_path)))
+        b = _decision(_run(_PUSH_GUARD, split, cwd=str(tmp_path)))
+        assert a == b, (
+            f"the attached form decided {a!r} and the split form {b!r}, for the "
+            "same command. A value read as a verb is the likely cause"
+        )
+        assert a == "allow", (
+            f"an ordinary option value now costs a confirmation ({a!r}). In a "
+            "dispatched session an ask is a refusal nobody can answer"
+        )
 
     def test_an_unreadable_program_alone_does_not_prompt(self, tmp_path):
         """The measured half that must NOT engage the net on its own.

--- a/tests/test_hooks/test_guard_ansic_fail_closed.py
+++ b/tests/test_hooks/test_guard_ansic_fail_closed.py
@@ -1055,11 +1055,17 @@ _HIDDEN_GIT_VERB = [
     ("parameter_default", f"{GIT} ${{V:-{PUSH}}} origin main"),
     ("backtick_sub", f"{GIT} `echo {PUSH}` origin main"),
     ("indirect_expansion", f"{GIT} ${{!P}} origin main"),
+    # The POSITION-SHIFT case, which the others do not cover: an unquoted
+    # substitution containing a space is one word to bash and several tokens to
+    # shlex, so the option's value is only the head of a word and the walk lands
+    # on its tail — an ordinary-looking literal with the real verb behind it.
+    ("split_option_value", f"{GIT} -C $(echo a) {PUSH} origin main"),
 ]
 _HIDDEN_GH_VERB = [
     ("gh_group", f'gh $"pr" {MERGE} 5'),
     ("gh_verb", f'gh pr $"{MERGE}" 5'),
     ("gh_verb_hex", f"gh pr {_hex_word(MERGE)} 5"),
+    ("gh_split_option_value", f"gh -R $(echo o/r) pr {MERGE} 5"),
 ]
 # Ordinary work carrying the same characters OUTSIDE verb position, which must
 # stay clean. This is the over-block surface: `$` in an argument is routine,
@@ -1071,6 +1077,14 @@ _BENIGN_EXPANSIONS = [
     ("tilde_exe_path", "~/venv/bin/python -m pytest tests/x.py"),
     ("variable_exe_dir", "$VENV/bin/python -m pytest tests/x.py"),
     ("subcommand_then_var", f"{GIT} log --format=$FMT -1"),
+    # The CONTROL for the position-shift case above: QUOTED, so it stays one
+    # token, the walk keeps its place, and the verb resolves. Without this the
+    # split-word rule could be a blanket "any substitution in an option value"
+    # and nothing here would notice.
+    ("quoted_option_value", f'{GIT} -C "$(pwd)" status'),
+    # Parentheses that are DATA, not syntax. A rule reading every paren as a
+    # substitution boundary would flag this ordinary formatting string.
+    ("format_string_parens", f'{GIT} for-each-ref --format="%(refname)" refs/heads'),
 ]
 
 

--- a/tests/test_hooks/test_guard_ansic_fail_closed.py
+++ b/tests/test_hooks/test_guard_ansic_fail_closed.py
@@ -1080,6 +1080,18 @@ _HIDDEN_GH_VERB = [
 # and a rule that flagged it would be switched off within a week.
 _BENIGN_EXPANSIONS = [
     ("message_argument", f'{GIT} {COMMIT} -m "$MSG"'),
+    # CHARACTERIZATION, NOT A REQUIREMENT. A value-taking option's value is
+    # skipped unread, so an expansion there can inject a verb the parse never
+    # sees. That residual is PRE-EXISTING — measured base-vs-branch, these shapes
+    # are ALLOW on both — and left deliberately: flagging a non-literal value slot
+    # fires on 711 of 129,179 real commands (0.55%), dominated by `-C $WT` on a
+    # worktree path, against 15 for everything this module currently moves.
+    #
+    # This row pins what the guard does TODAY so the measured cost stays honest.
+    # It does NOT say the shape ought to pass. Anyone closing the residual should
+    # DELETE this row and add the shape to the hidden-verb list above — not argue
+    # with a green test. The reasoning and the price are beside
+    # `shell_parse._EXPANSION_MARKS`, in its LEFT column.
     ("dash_C_value", f"{GIT} -C $DIR status"),
     ("gh_api_endpoint", "gh api repos/o/r/issues/$n/comments --jq .[].body"),
     ("tilde_exe_path", "~/venv/bin/python -m pytest tests/x.py"),

--- a/tests/test_hooks/test_guard_ansic_fail_closed.py
+++ b/tests/test_hooks/test_guard_ansic_fail_closed.py
@@ -1060,6 +1060,14 @@ _HIDDEN_GIT_VERB = [
     # shlex, so the option's value is only the head of a word and the walk lands
     # on its tail — an ordinary-looking literal with the real verb behind it.
     ("split_option_value", f"{GIT} -C $(echo a) {PUSH} origin main"),
+    # BRACE EXPANSION generates words with no substitution character anywhere, so
+    # the two-character rule above is blind to it on its own. The RANGE form is the
+    # one that matters: a comma list emits at least two words and corrupts the rest
+    # of argv, while identical range endpoints emit exactly ONE — argv intact.
+    # Both are held here so a later narrowing to "only the comma form" fails.
+    ("brace_range_single_word", f"{GIT} pus{{h..h}} origin main"),
+    ("brace_range_split", f"{GIT} p{{u..u}}s{{h..h}} origin main"),
+    ("brace_list", f"{GIT} pu{{s,s}}h origin main"),
 ]
 _HIDDEN_GH_VERB = [
     ("gh_group", f'gh $"pr" {MERGE} 5'),
@@ -1085,6 +1093,11 @@ _BENIGN_EXPANSIONS = [
     # Parentheses that are DATA, not syntax. A rule reading every paren as a
     # substitution boundary would flag this ordinary formatting string.
     ("format_string_parens", f'{GIT} for-each-ref --format="%(refname)" refs/heads'),
+    # Braces that bash does NOT expand. A group needs a top-level comma or range to
+    # expand at all, so these are literal text — and a rule that flagged every brace
+    # would flag ordinary work while claiming to be about word generation.
+    ("literal_brace_no_comma", f"{GIT} log --format={{short}} -1"),
+    ("brace_outside_verb_position", f"{GIT} checkout -- src/{{a,b}}.py"),
 ]
 
 
@@ -1158,6 +1171,32 @@ class TestVerbPositionIsUnestablished:
         segs, blind = sp.analyze_checked("$PY -m pytest tests/x.py")
         assert any(s.verb_unresolved for s in segs), "the fact must still be recorded"
         assert blind is None, f"reporting this cause was measured too expensive: {blind}"
+
+    @pytest.mark.parametrize(
+        "word,expands",
+        [
+            ("{a,b}", True),
+            ("{a..b}", True),
+            ("{a..a}", True),  # ONE word out — the argv-intact form
+            ("{,}", True),
+            ("{{a,b}}", True),  # the INNER group expands, so bash expands the word
+            ("{a}", False),  # no comma, no range: literal to bash
+            ("{}", False),
+            ("a{b}c", False),
+            ("{a", False),  # unterminated
+            ("a}", False),
+            ("--format=%(refname)", False),
+        ],
+    )
+    def test_the_brace_detector_matches_bash(self, word, expands):
+        """Each expectation was VERIFIED against bash itself, not reasoned about.
+
+        The two brace forms look alike and behave differently, and a detector
+        tuned to the wrong half is the failure this case exists to prevent. A
+        rule that flagged every brace would also flag ordinary text, so the
+        negative rows carry as much weight as the positive ones.
+        """
+        assert sp._has_brace_expansion(word) is expands
 
     def test_a_bound_still_outranks_the_new_cause(self):
         """Precedence, at the intersection where it can be wrong.

--- a/tests/test_hooks/test_guard_ansic_fail_closed.py
+++ b/tests/test_hooks/test_guard_ansic_fail_closed.py
@@ -1026,3 +1026,200 @@ class TestNetDoesNotDowngradeHardBlocks:
         cmd = f'{GIT} {COMMIT} {NV} -m "x"{suffix}'
         r = _run(_PUSH_GUARD, cmd, cwd=_REPO)
         assert _decision(r) == "block", r.stdout + r.stderr
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# VERB POSITION — an operation name the SHELL builds is unestablished, not
+# absent. shlex implements quote removal faithfully and implements no
+# expansion at all, so a word carrying `$` or a backtick tokenizes CLEANLY
+# into a token one or more characters off from the word bash runs. When such
+# a word sits where the operation is chosen, the parse reports success while
+# naming something else, and `untokenizable` — which answers "did the parse
+# fail" — has nothing to report. The forms are fixture data below; the
+# property is that a verb the parser cannot ESTABLISH must not read as absent.
+# ══════════════════════════════════════════════════════════════════════════
+MERGE = "mer" + "ge"
+
+
+def _hex_word(word: str) -> str:
+    """A word spelled as hex escapes inside a `$'...'` span."""
+    return "$'" + "".join(f"\\x{ord(c):02x}" for c in word) + "'"
+
+
+# Each pair is (id, command). The gated verb is built by the shell in every
+# one; none of them tokenizes badly, which is the point.
+_HIDDEN_GIT_VERB = [
+    ("locale", f'{GIT} $"{PUSH}" origin main'),
+    ("hex_escape", f"{GIT} {_hex_word(PUSH)} origin main"),
+    ("command_sub", f"{GIT} $(echo {PUSH}) origin main"),
+    ("parameter_default", f"{GIT} ${{V:-{PUSH}}} origin main"),
+    ("backtick_sub", f"{GIT} `echo {PUSH}` origin main"),
+    ("indirect_expansion", f"{GIT} ${{!P}} origin main"),
+]
+_HIDDEN_GH_VERB = [
+    ("gh_group", f'gh $"pr" {MERGE} 5'),
+    ("gh_verb", f'gh pr $"{MERGE}" 5'),
+    ("gh_verb_hex", f"gh pr {_hex_word(MERGE)} 5"),
+]
+# Ordinary work carrying the same characters OUTSIDE verb position, which must
+# stay clean. This is the over-block surface: `$` in an argument is routine,
+# and a rule that flagged it would be switched off within a week.
+_BENIGN_EXPANSIONS = [
+    ("message_argument", f'{GIT} {COMMIT} -m "$MSG"'),
+    ("dash_C_value", f"{GIT} -C $DIR status"),
+    ("gh_api_endpoint", "gh api repos/o/r/issues/$n/comments --jq .[].body"),
+    ("tilde_exe_path", "~/venv/bin/python -m pytest tests/x.py"),
+    ("variable_exe_dir", "$VENV/bin/python -m pytest tests/x.py"),
+    ("subcommand_then_var", f"{GIT} log --format=$FMT -1"),
+]
+
+
+class TestVerbPositionIsUnestablished:
+    """shell_parse: the parse succeeds, and must SAY the verb is unreadable."""
+
+    @pytest.mark.parametrize("name,cmd", _HIDDEN_GIT_VERB + _HIDDEN_GH_VERB)
+    def test_the_parse_succeeds_so_the_older_probe_cannot_see_it(self, name, cmd):
+        """CONTROL for the whole class, and the reason it needed a new rule.
+
+        If any of these were untokenizable, the pre-existing net would already
+        have caught it and nothing below would be load-bearing. Assert the
+        premise rather than trusting it.
+        """
+        assert sp.untokenizable(cmd) is False, (
+            f"{name} does not tokenize, so this case is already covered by the "
+            "older probe and proves nothing about the verb-position rule"
+        )
+
+    @pytest.mark.parametrize("name,cmd", _HIDDEN_GIT_VERB)
+    def test_the_ordinary_gate_still_does_not_see_the_git_verb(self, name, cmd):
+        """Pins that nothing here half-decodes the word into a real verb.
+
+        A decoder that guessed would hand a hard policy verdict to a command
+        whose operation it does not actually know. The rule reports rather
+        than guesses, so the resolved subcommand must stay wrong.
+        """
+        segs = sp.analyze(cmd)
+        assert not any(s.exe == "git" and sp.git_subcommand(s.argv) == PUSH for s in segs)
+
+    @pytest.mark.parametrize("name,cmd", _HIDDEN_GIT_VERB + _HIDDEN_GH_VERB)
+    def test_a_shell_built_verb_is_reported_as_a_blind_spot(self, name, cmd):
+        segs, blind = sp.analyze_checked(cmd)
+        assert blind is sp._BLIND_UNRESOLVED_VERB, (
+            f"{name}: the parse resolved a verb bash never runs and reported "
+            f"{blind!r}. A guard reading the empty gated-segment list cannot "
+            "tell that from a command with no gated operation at all"
+        )
+        assert any(s.verb_unresolved for s in segs)
+
+    @pytest.mark.parametrize("name,cmd", _BENIGN_EXPANSIONS)
+    def test_an_expansion_outside_verb_position_stays_clean(self, name, cmd):
+        segs, blind = sp.analyze_checked(cmd)
+        assert blind is None, f"{name} was flagged: {blind}"
+        assert not any(s.verb_unresolved for s in segs)
+
+    def test_the_escape_free_decode_from_1686_still_resolves(self):
+        """REGRESSION: the shipped decode must keep producing a real verb.
+
+        A rule that flagged every `$`-bearing verb-position token WITHOUT
+        looking at the decoded form would flag this one too, and the gate that
+        currently fires its ordinary verdict on it would drop to a prompt.
+        """
+        segs, blind = sp.analyze_checked(f"{GIT} $'{PUSH}' origin main {FORCE}")
+        assert any(s.exe == "git" and sp.git_subcommand(s.argv) == PUSH for s in segs)
+        assert blind is None, f"the decoded form must not read as unreadable: {blind}"
+
+    def test_an_unreadable_program_is_recorded_but_not_reported(self):
+        """The PRICED HALF, pinned in both directions so neither can drift.
+
+        A program named by a variable is the same failure — nothing about the
+        segment is established — but it is ordinary work here at three orders
+        of magnitude more volume: 1,845 of 129,179 real commands against 14.
+        Reporting it MEASURED 203 extra push prompts, 206 commit prompts, and
+        one command going block -> allow, because `protected_paths_guard`
+        answers a non-bounds blind spot by swapping its precise scan for a
+        weaker substring test. So the fact is recorded on the segment and the
+        chokepoint stays quiet, and both halves of that are asserted: dropping
+        the record loses the fact, reporting it re-buys the cost.
+        """
+        segs, blind = sp.analyze_checked("$PY -m pytest tests/x.py")
+        assert any(s.verb_unresolved for s in segs), "the fact must still be recorded"
+        assert blind is None, f"reporting this cause was measured too expensive: {blind}"
+
+    def test_a_bound_still_outranks_the_new_cause(self):
+        """Precedence, at the intersection where it can be wrong.
+
+        A command can be over a bound AND carry a shell-built verb. Consumers
+        that restore what a bound took away branch on `bounds_induced`, so
+        reporting the verb cause there would hand them the one answer they are
+        documented to ignore.
+        """
+        inner = f"{GIT} {_hex_word(PUSH)} origin main"
+        cmd = 'bash -c "$(' * 9 + inner + ')"' * 9
+        _segs, blind = sp.analyze_checked(cmd)
+        assert blind is not None and blind.bounds_induced, (
+            f"a bounded parse must report the bound, not a verb cause: {blind}"
+        )
+
+
+class TestVerbPositionReachesTheGuard:
+    """git_push_guard: the parser's signal has to become a VERDICT.
+
+    A blind spot nothing acts on is a field with a docstring. These run the
+    real guard, which is also the only way to exercise the conjunct deciding
+    whether the net engages at all.
+    """
+
+    @pytest.mark.parametrize("name,cmd", _HIDDEN_GIT_VERB + _HIDDEN_GH_VERB)
+    def test_a_hidden_gated_verb_reaches_a_human(self, name, cmd, tmp_path):
+        r = _run(_PUSH_GUARD, cmd, cwd=str(tmp_path))
+        assert _decision(r) in ("ask", "block"), (
+            f"{name} was decided without a human. The guard found no gated "
+            f"segment and no reason to doubt that.\n{r.stdout}{r.stderr}"
+        )
+
+    @pytest.mark.parametrize("name,cmd", _BENIGN_EXPANSIONS)
+    def test_ordinary_expansions_are_not_newly_prompted(self, name, cmd, tmp_path):
+        r = _run(_PUSH_GUARD, cmd, cwd=str(tmp_path))
+        assert _decision(r) == "allow", (
+            f"{name} newly costs a confirmation. Measured over 129,179 real "
+            "commands the rule moves 14 of them; a shape in this list moving "
+            f"means that number is wrong.\n{r.stdout}{r.stderr}"
+        )
+
+    def test_a_hidden_verb_is_refused_outright_when_nobody_can_answer(self, tmp_path):
+        """A dispatched session has no human, so the ask has to become a deny.
+
+        Mirrors the existing dispatched legs: where no ask is available, not
+        refusing means permitting.
+        """
+        cmd = f'{GIT} $"{PUSH}" origin main'
+        r = _run(_PUSH_GUARD, cmd, cwd=str(tmp_path), dispatched="1")
+        assert _decision(r) == "block", r.stdout + r.stderr
+
+    def test_an_unreadable_program_alone_does_not_prompt(self, tmp_path):
+        """The measured half that must NOT engage the net on its own.
+
+        1,845 of 129,179 real commands name their program with a variable —
+        an interpreter or a remote shell held in one is ordinary work here.
+        Engaging on that turns the net into an outage, and MEASURED it also
+        moved one command block -> allow through a sibling guard.
+        """
+        r = _run(_PUSH_GUARD, "$PY -m pytest tests/x.py", cwd=str(tmp_path))
+        assert _decision(r) == "allow", r.stdout + r.stderr
+
+    def test_an_unreadable_program_is_the_documented_residual(self, tmp_path):
+        """CHARACTERIZATION, not an endorsement. Pinned so the gap is visible.
+
+        A command whose PROGRAM is a variable is read exactly as it is on the
+        default branch, whether or not it spells the operation — the net keys
+        on a blind spot, and this cause is deliberately not reported. This is
+        the boundary of what the verb-position rule closes; it is recorded
+        here so a later change that closes it fails LOUDLY on this assertion
+        rather than passing unnoticed, and so nobody reads the class above as
+        covering it.
+        """
+        r = _run(_PUSH_GUARD, f"$G {PUSH} origin main {FORCE}", cwd=str(tmp_path))
+        assert _decision(r) == "allow", (
+            "the residual closed without this test being updated — that is "
+            f"good news, but say so deliberately.\n{r.stdout}{r.stderr}"
+        )

--- a/tests/test_hooks/test_protected_paths_guard.py
+++ b/tests/test_hooks/test_protected_paths_guard.py
@@ -423,3 +423,65 @@ class TestBoundedParseNeverDowngradesToTheWeakerCheck:
         assert r.returncode == 0, (
             f"a buried non-rm command was blocked: out={r.stdout!r} err={r.stderr!r}"
         )
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# A BLIND SPOT MUST NOT DISARM THE PRECISE SCAN
+#
+# For a NON-BOUNDS blind spot this guard runs its substring fallback, which its
+# own comment calls STRICTLY WEAKER than the segment scan — a substring test
+# cannot see an ANCESTOR of a protected directory, nor a GLOB over its contents,
+# because neither contains a protected path as a substring. That fallback used
+# to RETURN, so any such blind spot skipped the scan entirely.
+#
+# Latent while `untokenizable` was the only non-bounds cause; reachable once
+# there were two. MEASURED base-vs-branch, pairing a verb the shell builds with
+# an rm of the PARENT of the production database went BLOCK -> ALLOW. The
+# fallback now ADDS to the scan rather than replacing it.
+# ══════════════════════════════════════════════════════════════════════════
+
+# A segment whose operation the parser cannot establish, so `analyze_checked`
+# reports a non-bounds blind spot. Fixture data, per the sibling guard suites.
+_BLINDING_PREFIX = "git pus{h..h} origin main && "
+
+
+@pytest.mark.parametrize(
+    "target",
+    [f"{H}/genesis", f"{H}/genesis/*"],
+    ids=["ancestor", "glob"],
+)
+def test_a_blind_spot_does_not_disarm_the_precise_scan(target, fake_home):
+    """The two shapes the substring fallback structurally cannot see.
+
+    Each must still be refused when the command ALSO carries a blind spot.
+
+    The control is what makes this mean anything, and it is not decoration: the
+    same rm WITHOUT the prefix must already be refused, so a fixture whose
+    protected paths failed to resolve — or a guard that refused everything —
+    cannot pass this silently. The pair is the assertion.
+    """
+    plain = _run(f"rm -rf {target}", fake_home)
+    assert plain.returncode == 2, (
+        "CONTROL: the bare rm was not refused, so this fixture's protected paths "
+        f"do not resolve and the assertion below proves nothing.\n{plain.stderr}"
+    )
+    blinded = _run(f"{_BLINDING_PREFIX}rm -rf {target}", fake_home)
+    assert blinded.returncode == 2, (
+        "an rm the precise scan catches was ALLOWED because the command also "
+        "carried a blind spot — the substring fallback replaced the scan instead "
+        f"of adding to it, and it cannot see this shape.\n{blinded.stderr}"
+    )
+
+
+def test_the_blinding_prefix_really_blinds(fake_home):
+    """The other half of the control: prove the prefix does what it claims.
+
+    If it stopped raising a blind spot, the tests above would still pass — via
+    the ordinary path — while covering nothing. Asserted against the parser
+    directly rather than inferred from a verdict.
+    """
+    _segs, blind = shell_parse.analyze_checked(_BLINDING_PREFIX + "rm -rf /tmp/x")
+    assert blind is not None and not blind.bounds_induced, (
+        "the prefix no longer produces a NON-BOUNDS blind spot, so the "
+        f"fall-through tests above exercise the ordinary path: {blind}"
+    )

--- a/tests/test_hooks/test_shell_parse_nesting_cost.py
+++ b/tests/test_hooks/test_shell_parse_nesting_cost.py
@@ -136,6 +136,134 @@ def test_an_adversarial_command_stays_inside_the_guard_budget():
     assert elapsed < 1.0, f"took {elapsed:.2f}s against a 5s budget shared by three guards"
 
 
+# ══════════════════════════════════════════════════════════════════════════
+# THE VERB-WORD SCANS — a second cost axis, on the same fail-open.
+#
+# `_has_brace_expansion` runs per WORD rather than per command, so it is not
+# bounded by MAX_COMMAND_CHARS or MAX_SUBSTITUTION_DEPTH. Its first version
+# restarted an inner walk at every `{`, which is O(n^2): MEASURED 0.014s at 500
+# characters, 5.5s at 8,000, 173s at the command cap — against guards registered
+# at 10s. A hook that runs out of clock does not refuse, it PERMITS, and this
+# module feeds nine of them, so one crafted word disengaged all of them at once.
+#
+# A correctness test cannot see this class: the quadratic scan returned the RIGHT
+# answer, just far too late. These are the tests that would have caught it.
+# ══════════════════════════════════════════════════════════════════════════
+
+
+def _brace_cost(n: int, reps: int = 5) -> float:
+    """Median seconds to scan a word of *n* unterminated brace openers.
+
+    The median rather than a single sample: this box runs live services, and one
+    scheduling hiccup in a sub-millisecond measurement is the difference between
+    a green suite and a flaky one.
+    """
+    word = "{" * n
+    samples = []
+    for _ in range(reps):
+        started = time.monotonic()
+        sp._has_brace_expansion(word)
+        samples.append(time.monotonic() - started)
+    return sorted(samples)[len(samples) // 2]
+
+
+def test_the_brace_scan_cost_is_linear_in_word_length():
+    """The durable property is the SHAPE, so this asserts a ratio, not a constant.
+
+    Quadrupling the length must roughly quadruple the cost. A quadratic scan
+    SIXTEENS it, so the bound sits between: 8x passes linear with room for load
+    noise and fails quadratic by a factor of two. MEASURED on this box after the
+    rewrite: 4.17x. Before it: ~16x.
+    """
+    small, large = _brace_cost(8_000), _brace_cost(32_000)
+    assert large < small * 8.0, (
+        f"4x the length cost {large / max(small, 1e-9):.1f}x the time "
+        f"({small:.5f}s -> {large:.5f}s) — the scan is superlinear again, which "
+        "is a fail-open: a guard killed by its wall clock permits"
+    )
+
+
+def test_the_brace_scan_absorbs_the_worst_word_the_parser_can_hold():
+    """The absolute number, on the SCAN ITSELF rather than through a caller.
+
+    MEASURED 0.006s at MAX_COMMAND_CHARS after the rewrite and 173s before it, so
+    a 2s bound clears linear by ~300x and fails a reintroduced quadratic scan by
+    ~85x. That budget is the 5s `bash_safety_hook.sh` shares across the three
+    guards it delegates to.
+
+    CALLS THE FUNCTION DIRECTLY, and the two failed attempts that preceded this
+    are the reason. Through `analyze_checked` the payload never reaches the scan:
+    a word of MAX_COMMAND_CHARS braces puts the whole COMMAND over the length
+    bound, which refuses in microseconds; and sizing the word just under that
+    bound instead hits `_MAX_VERB_WORD_CHARS`, which short-circuits before the
+    scan for the same reason it exists. Both versions passed against the very
+    quadratic scan they were written to catch. The caller is armoured twice over —
+    which the test below pins — so the only way to time the scan is to call it.
+    """
+    word = "{" * sp.MAX_COMMAND_CHARS
+    started = time.monotonic()
+    sp._has_brace_expansion(word)
+    elapsed = time.monotonic() - started
+    assert elapsed < 2.0, (
+        f"one crafted word cost {elapsed:.2f}s to scan, against a 5s budget shared "
+        "by three guards. A hook SIGKILLed mid-gate does not block the tool call — "
+        "it permits, on all nine guards this module feeds"
+    )
+
+
+def test_the_verb_word_cap_keeps_a_long_word_out_of_the_scan_entirely():
+    """Defence in depth, asserted rather than assumed — and its DIRECTION.
+
+    The scan is linear now, so this cap is the belt to that pair of braces: it
+    stops an over-long word before any scanning at all, so a future edit that
+    reintroduces a slow scan cannot reach a guard through this path. Pinning it
+    matters because it is invisible in ordinary runs and would be easy to delete
+    as redundant.
+
+    The payload is deliberately UNDER the command-length bound and OVER the word
+    cap, so it is the cap that fires and not the bound — asserted, because those
+    two refusals are indistinguishable from a timing alone, and mistaking one for
+    the other is what made two earlier versions of the test above vacuous.
+    """
+    word_len = sp._MAX_VERB_WORD_CHARS * 2
+    cmd = "git " + "{" * word_len + " origin main"
+    assert len(cmd) < sp.MAX_COMMAND_CHARS, "payload must stay UNDER the length bound"
+    started = time.monotonic()
+    _segs, blind = sp.analyze_checked(cmd)
+    elapsed = time.monotonic() - started
+    assert blind is sp._BLIND_UNRESOLVED_VERB, (
+        "an over-long verb word must be reported UNRESOLVED — the fail-closed "
+        f"direction — and by the word cap rather than a bound: {blind}"
+    )
+    assert elapsed < 1.0, f"the cap took {elapsed:.2f}s, so it is not short-circuiting"
+
+
+def test_an_unreadable_verb_word_fails_CLOSED():
+    """The cap's DIRECTION, which is the half a length bound usually gets wrong.
+
+    Declining to read a word is not evidence the word is harmless, so an
+    over-long word is reported not-literal — the same verdict this module gives
+    any verb it cannot establish. Asserting the direction rather than the number:
+    a cap that answered "literal" would be a silent allow at a length the
+    attacker picks.
+
+    The pair is the point. At the cap the answer is still LITERAL, so the test
+    fails if the bound is ever moved to where it would swallow ordinary words —
+    MEASURED, the longest word ever reaching this function across 129,179 real
+    commands is 3,176 characters.
+    """
+    at_cap = "a" * sp._MAX_VERB_WORD_CHARS
+    over_cap = "a" * (sp._MAX_VERB_WORD_CHARS + 1)
+    assert sp._word_is_literal(at_cap) is True, (
+        "a word AT the cap must still be read — otherwise the cap is cutting into "
+        "ordinary traffic rather than bounding an attack"
+    )
+    assert sp._word_is_literal(over_cap) is False, (
+        "an over-long word was reported LITERAL, so a guard would treat a word "
+        "this module never read as established. The cap must fail closed"
+    )
+
+
 @pytest.mark.parametrize("depth", [16, 48, 128])
 def test_a_truncated_parse_reports_itself(depth):
     """The half that makes the bound safe rather than a different fail-open.

--- a/tests/test_hooks/test_worktree_guard.py
+++ b/tests/test_hooks/test_worktree_guard.py
@@ -688,3 +688,51 @@ class TestCommandCarriersAreNotAHole:
         inner = f"echo /tmp/wt-x | xargs {_PHRASE}"
         result = _run_guard(guard_cmd, {"command": inner})
         assert result.returncode == 0, result.stdout + result.stderr
+
+
+# ---------------------------------------------------------------------------
+# A NON-TRUNCATING blind spot must not swap the parse for the raw-text regex
+# ---------------------------------------------------------------------------
+
+_WT = "work" + "tree"
+_RM = "rem" + "ove"
+
+
+class TestBlindSpotDoesNotDegradeToProse:
+    """The legacy extractor reads RAW TEXT, so it cannot tell a command from a
+    sentence. It is the right fallback for a cause that leaves NO segments — a
+    bound — and the wrong one for a cause that leaves the segments complete.
+
+    MEASURED when this guard degraded on any blind spot: a `gh pr` whose verb
+    was a variable, with a --body whose prose merely mentions removing a
+    worktree, went ALLOW -> hard BLOCK. Sessions write that PR body constantly;
+    this PR's own body does.
+    """
+
+    def test_prose_in_a_pr_body_is_not_blocked(self, guard_cmd: str) -> None:
+        cmd = f'gh pr "$ACTION" 123 --body "docs about {_WT} {_RM} semantics"'
+        result = _run_guard(guard_cmd, {"command": cmd})
+        assert result.returncode == 0, (
+            "prose describing a worktree removal was BLOCKED because the command "
+            f"also carried a blind spot.\n{result.stderr}"
+        )
+
+    def test_the_same_prose_with_a_readable_verb_is_the_control(
+        self, guard_cmd: str
+    ) -> None:
+        """CONTROL: identical text, verb spelled out. If this blocked too, the
+        test above would be measuring the prose rule and not the blind path."""
+        cmd = f'gh pr edit 123 --body "docs about {_WT} {_RM} semantics"'
+        result = _run_guard(guard_cmd, {"command": cmd})
+        assert result.returncode == 0, result.stderr
+
+    def test_a_real_removal_alongside_a_blind_spot_still_blocks(
+        self, guard_cmd: str
+    ) -> None:
+        """The other direction, so this is not a licence to stop looking: an
+        ACTUAL removal must still be refused when a blind spot is present."""
+        cmd = f"git pus{{h..h}} origin main && git {_WT} {_RM} /home/ubuntu/wt/x"
+        result = _run_guard(guard_cmd, {"command": cmd})
+        assert result.returncode == 2, (
+            f"a real worktree removal was allowed.\n{result.stdout}{result.stderr}"
+        )


### PR DESCRIPTION
## The problem

The shared parser behind the approval guards resolves each command segment with
Python's `shlex`. `shlex` reproduces quoting and backslash escapes faithfully, and
implements no shell expansion whatsoever. So a word that carries a substitution
tokenizes **cleanly** into a token that is not the word bash finally runs.

When that word is the one choosing the operation, three things happen together:

- `git_subcommand()` returns a token no gate matches, so no gated verb is seen;
- `untokenizable()` reports `False`, because nothing failed to parse;
- the blind-spot nets that engage on `blind is not None` therefore stand down.

The guards are left holding a tidy parse that names nothing they gate — which is
byte-for-byte the answer they give for a command that gates nothing at all. The
parser's failure mode here is not "cannot read"; it is "read successfully, and
resolved something else", and that is the one thing the existing self-report was
structurally unable to say.

## Why a rule rather than another decode

#1686 closed one spelling of this by decoding that spelling. Handling each form as
it turns up is a treadmill, and the treadmill is visible in the history: the
docstring calling the remaining case "the one residual" was already wrong when it
was written.

So each construct gets an **allowlist** rule rather than a list of the spellings
that fool it. A verb-position word free of the two characters that open a
substitution is a word `shlex` and bash agree on *as far as substitution goes*,
whatever else it contains. A denylist's misses are holes; an allowlist's misses are
inconveniences, and on a safety boundary that asymmetry is the whole argument.
Spellings nobody has enumerated are covered by construction.

**What is not claimed:** that this is the complete set of word-generating
constructs. That sentence is the one that keeps being wrong on this file, so the
code now carries a two-column table instead — **covered** (substitution, brace
expansion, each with its rule) and **left** (tilde expansion, pathname expansion,
each with its reason) — closing with "a construct absent from both columns is
unexamined, not covered."

## The change

- `shell_parse._verb_unresolved()` marks a segment whose verb-position words carry
  a substitution — the executable's basename, and for a multi-verb dispatcher the
  words selecting the subcommand. Arguments are deliberately out of scope: a
  variable in an argument is routine work.
- `analyze_checked()` reports it as a new blind-spot cause, placed **after** all
  three existing causes, so every command that already had a blind spot keeps the
  exact cause and hint it had.
- `git_push_guard` ORs the fact into its net's engage-test. That test looks for the
  operation's **name** in the raw text, which is sound for every other cause and
  unsound for this one, because here the name is the missing part. The verdict
  ladder underneath is untouched, so the new cause inherits ask-with-a-human and
  deny-when-dispatched rather than adding a ladder of its own.
- `BlindSpot` deliberately does **not** grow a field. It is locked to a single
  decision for reasons its own docstring measures, and the extra fact the guard
  needed is a property of the parsed segment, read against the guard's own list of
  gated programs. Which programs are gated is the guard's question; why the parse
  is blind is the parser's.

`#1686`'s escape-free decode runs before the new check, so a decoded verb still
resolves and still reads as a clean parse. That is pinned by a test that asserts
both halves.

## Measured, not estimated

Cost was measured end to end rather than by parse diff, because a parse difference
only matters if a guard's verdict actually moves.

Corpus: every Bash command in 11,488 Claude Code transcripts on this install —
**168,026 invocations, 129,265 unique**.

- **Stage 1** — parse diff, both trees loaded side by side: 14 commands change
  blind state. The transition table shows nothing else moving:
  `untokenizable -> untokenizable` 2,086, `bounds -> bounds` 1,
  `none -> none` 127,078, `none -> new cause` 14.
- **Stage 2** — the real guards run as subprocesses against both trees in a pinned
  environment, counting verdict changes: **14 push and 10 commit verdicts move,
  every one of them `allow → ask`**. Zero movement in `protected_paths_guard`,
  `worktree_cwd_guard`, `git_discard_guard`, `full_suite_guard`.

**15 distinct commands change verdict — 0.0116% of unique commands, 0.0089% of
invocations, zero fail-opens.** They are dominated by earlier sessions probing
these very guards, plus a few `git -C <path containing a substitution>` shapes.

> The first two rounds of this PR reported 14, and that was an undercount from a
> flawed selection: stage 1 picked candidates on *"the parser's blind verdict
> changed"*, which cannot see a command that was **already** blind and where only a
> guard's engage-test moved. Selection now uses a superset of anything either tree
> can move, giving 75 candidates (0.058%) and the corrected figures above.

## A wider version was measured and not shipped

The same idea extended to a command whose **program** is named by a variable
(`$PY x.py`, `$SSH host …`) covers strictly more, and costs far more: 1,845 of
129,179 real commands, 203 extra push prompts, 206 commit prompts — and one real
command going **block -> allow**.

That last one is not a flaw in the rule. `protected_paths_guard` answers a
non-bounds blind spot by replacing its precise segment scan with a substring
fallback its own comment calls strictly weaker, so *any* newly reported non-bounds
cause can turn one of its refusals into an allow. Filing that separately.

Here, the fact is recorded on the segment and the chokepoint stays quiet about it.
The residual that leaves is written out in the code beside the new cause and pinned
by a characterization test, so a later change that closes it fails loudly rather
than passing unnoticed.

## Follow-on commit: a split option value shifts the verb slot

Self-review of the first commit found the one slot its walk leaves unread. The walk
consumes a value-taking option's value without inspecting it, on the correct ground
that a value is not verb position — but an unquoted `$( … )` containing a space is
one word to bash and several tokens to `shlex`, so skipping the *head* of a split
word leaves the walk standing on that word's *tail*. It then reports "verb read
plainly" while pointing at the wrong token, and the operation behind it is invisible
to every gate and to the net.

Pre-existing on `main` rather than introduced here, but it is the same three-part
failure this PR is about, so leaving it would make the first commit's claim broader
than what it delivers.

`_word_continues()` detects a word that carries on into the next tokens and the walk
refuses to skip such a value. Parentheses **not** opened by `$` stay data —
`--format="%(refname)"` is ordinary work and is pinned as a control, as is the
quoted form `-C "$(pwd)"`, which stays one token and must still resolve.

The blunt version of this — flag any substitution in an option value — measured at
**711 additional commands (0.55%)**, dominated by `git -C "$B"` shapes that desync
nothing. The precise version measures at **zero**: both measurement stages were
re-run in full and returned numbers identical to the first commit.

## Third commit: brace expansion, and the completeness claim

Review found that the two-character rule does not cover **brace expansion**, which
generates words with neither character present — while the comment beside it claimed
that allowlist was complete. False, and false in the way this PR exists to correct:
#1686's docstring called a hex-encoded verb "the one residual" and was already wrong
when written; mine repeated the shape one revision later.

The finding arrived with a structural argument that brace expansion always emits at
least two words, so the extra word lands beside the verb and corrupts the rest of
argv — real, self-limiting, and enough to justify documenting the gap rather than
closing it. Verified independently against bash through a shim printing its own
argv, that holds for the **comma** form only. A brace **sequence** with identical
endpoints emits exactly **one** word, so the command runs with argv intact and was
allowed on both trees. A working construction, not a degraded one — so it is closed
rather than documented.

`_has_brace_expansion` detects a group whose top level holds a comma or a `..`
range, nesting-aware. Groups bash does *not* expand — `{a}`, `{}`, `a{b}c`, an
unterminated `{a` — stay literal, and every row of the detector table was
cross-checked against bash itself rather than reasoned about, because the two forms
look alike and behave differently.

**Cost re-measured in full:** identical to the previous two commits — 14 commands,
13 push and 10 commit verdicts moving `allow→ask`, nothing elsewhere. The brace rule
costs **zero** additional commands over 129,179, so extending the rule was affordable
and the document-only option was not needed.

Verify-RED, two mutations: disconnecting the brace check reds the three brace cells
at the parser and at the guard; removing only the **range** half — the exact
narrowing the reported severity would have licensed — reds both range cells plus the
`{a..b}` and `{a..a}` rows of the detector table, while the comma cell stays green.

## Fourth commit: the brace scan re-read its input

Review found the brace detector from the third commit is **quadratic** — the outer
loop scanned for an opener, the inner loop ran to end-of-token whenever no closer
matched. Measured on that function: 0.014s at 500 characters, 5.5s at 8,000, and
**173s at the parser's own length cap**, against 0.004s for the same length of
brace-free text.

That is a **fail-open**, not a slow path. A hook that overruns its wall clock is
killed, and the hook contract treats a timed-out hook as non-blocking — so the
guard *permits*. Five consumers are registered at 10s, and the shared budget the
parser calibrates against is 5s; at 8,000 characters that is already gone. Nine
guards read this parser, so one crafted word disengaged all of them. The third
commit closed one concealment class and opened a way to switch off the gate stack.

The scan is now a **single left-to-right pass** with a stack of per-group flags: a
`{` already passed can only be the group the next `}` closes, so no character is
re-read. **173s → 0.031s.** Behaviour is proven unchanged rather than spot-checked
— old vs new over **3,435,004 words** (exhaustive across the branch-driving
alphabet, 300,000 randomised, and every argv token of every corpus command): **zero
mismatches**. A word-length cap backs it up and **fails closed**, derived from the
corpus (longest word ever reaching that function: 3,176 characters).

Four cost tests pin it, because a correctness suite cannot see this class — the
quadratic scan returned the *right* answer, and all 39 existing tests passed
against it. Two earlier versions of the absolute test were vacuous and caught by
verify-RED: their payloads were refused by the length bound, then by the word cap,
before ever reaching the scan. That history is recorded in the test's docstring.

### A fail-open this branch had armed, now closed

Asked to price a sibling guard's degradation rather than inherit a null corpus
result, I constructed it. `protected_paths_guard` answered a non-bounds blind spot
by *returning* its substring fallback — which its own comment calls strictly
weaker, and which structurally cannot see an ancestor or a glob — so a concealed
verb paired with an `rm -rf` of the **parent of the production database** went
`BLOCK → ALLOW`. Latent while there was one non-bounds cause; reachable once there
were two. The fallback now blocks if it finds something and otherwise falls through
to the precise scan. Of 129,179 real commands, 1,697 mention `rm` and 68 reach that
branch; **zero change verdict**.

### A P2 I refuted too early — corrected in the fifth commit

I first tested the value-slot claim against **bash's own argv** across 15 shapes and
found zero concealment. That refutation was **incomplete**, and review found the
gap. Every one of my shapes wrote the gated verb *out after* the option, so my
argument — the parser consumes one token where bash consumes one word, therefore a
multi-word expansion leaves bash's verb earlier and the parser over-reads — held
only for shapes that shift an existing verb. An expansion in a value slot can also
**inject** one, and then there is no later verb to over-read: the parse simply never
sees it.

Verified against bash's argv and through the real guard: those shapes are `ALLOW` on
**base and branch alike**, so the residual is **pre-existing and not made worse
here**, with both controls (plain force push `BLOCK`, brace verb `ALLOW → ASK`)
still behaving.

The lesson is in the code: I varied the construct and held the verb's position
fixed, which is generating cases from a hypothesis rather than from the mechanism.
An axis a case set does not vary is an axis it proves nothing about.

## Fifth commit: the coverage claim, corrected for the third time

Prose and one fixture comment only — **zero executable lines change**, verified by a
diff scan rather than asserted, with the full candidate measurement re-run
afterwards returning the same 75 candidates.

- **Both `COVERED` rows now name a position**, not just a construct. The
  unqualified "brace expansion — COVERED" row was the sentence falsified this time;
  it is covered *in verb position*.
- **A new `LEFT` row for any expansion in a value slot**, carrying the mechanism,
  its pre-existing status, and its price.
- **`_word_continues` no longer claims to "close the position-shift case."** It
  closes the narrow sub-case where the skipped value is the unterminated *head* of a
  split word. Its "zero added flags" figure is what a narrow test costs, not
  evidence of coverage — putting a wide claim beside a small number is how the wrong
  sentence got written.

### The worse half was not a sentence

The `dash_C_value` fixture sat in the list the suite asserts must `ALLOW`, so the
residual was **test-enforced**: anyone closing it later would have had to argue with
a green test. It now reads as characterization and names the exit route — delete the
row, move the shape to the hidden-verb list.

### Priced, since the number decides the trade

Flagging a non-literal value slot fires on **711 of 129,179 real commands (0.55%,
0.44% of invocations)** against **15** for everything this rule currently moves —
**47x** — dominated by `git -C $WT` on a worktree path, the most ordinary thing done
in this repository. **Not closed**, and the number lives in the code so the next
person reaches the same conclusion without re-deriving it.

## Sixth commit: two over-block regressions, and a cost method replaced

Review found two regressions from the earlier commits. Both reproduced before
being touched, both fixed, both pinned.

**An attached option value was read as verb position.** `shlex` yields
`--git-dir=$DIR` as one token, and the walk tested the whole token — so an
ordinary `git --git-dir=$DIR status` asked for approval while the identical
*split* form did not. Two spellings of one command, two answers.

This is a **design-axiom violation**, not a nuisance: a background session must be
as capable as a foreground one, and an ask with nobody present is a block nobody
intended. An option is now recognised first and only its **name** is read, because
only the name can decide where the verb sits; an attached value rides in the same
token and is a value slot. Both forms now agree by construction. An unreadable
option *name* still nets — it can expand to a value-taking flag and consume the
following word.

**The worktree guard degraded to raw-text regex on any blind spot**, and its own
comment says why that was wrong: it justifies the fallback with *"a BOUND stopped
the parse — and `analyze_checked` then returns NO segments."* True of the bounds
causes; false of an unresolved verb, which leaves the segments complete. A
`gh pr` with a variable verb and a `--body` mentioning worktree removal went from
allowed to **hard-blocked** — prose, not a command. The fallback is now restricted
to truncating causes, the same shape as the protected-paths fall-through. A real
removal alongside a blind spot must still block, and that is asserted.

### The corpus missed both — so the method changed

Neither shape existed in the corpus. That is **four** null results from it that
were wrong. A corpus measures what has been *typed*, never what is *typeable*, and
for an over-block claim the population that matters is what the rule can fire on —
a property of the grammar, not of history.

Cost is now measured by **generating** from that grammar: 384 cells over program ×
option form × construct × position, each run through bash itself via an argv shim.

Two classifiers for it were wrong before the third was right, and the sequence is
recorded because it is the same error one level up:

| classifier | flaw | figure |
|---|---|---|
| "bash's verb turned out benign and we netted" | confuses what a command evaluated to with what could be *established* | 37% |
| "the parser agreed this time" | a coincidence test — `git -$V <verb>` agrees when `$V` is harmless, disagrees when it is `C` | 16.58% |
| **vary the environment, ask whether bash's verb MOVES** | — | **reported** |

**132 new nets, 60 on slots measured to move the verb.** The other 72 are cells the
test cannot adjudicate — a brace group's content does not depend on the
environment, so varying it can never move them — and they are labelled
*unadjudicated*, not clean. One narrow candidate false positive is named rather
than buried: `gh` resolves its verb by scanning for `pr`, so an unreadable option
name cannot move it.

Corpus figure re-run on the final tree for comparison and **unchanged**: 15
commands, 14 push and 10 commit prompts, zero movement elsewhere, zero fail-opens.

## Verification

Four mutations, each proven applied by sha256 before/after and compiled before
running, each restored from a hash-gated copy:

| mutation | RED | assertion that fired |
|---|---|---|
| dispatcher walk stops flagging | 19 | the defect assertion; the fixture precondition stayed green |
| executable basename check removed | 2 | both program-half cases |
| allowlist narrowed by one character | 2 | exactly the cells that character covers |
| the guard's OR removed | 3 | the cells whose text does not spell the operation |

The control is a base-vs-branch comparison through real guard subprocesses on two
checkouts, with the plain form as the cell that must stay `BLOCK` in both — if the
harness were inert, every cell would read identically and that row is what proves
it is not.

Targeted suites run and green: the parser suites, the guard-net suite, both push
guard surfaces, merge gate, escalation cap, discard, destructive, protected paths,
commit review enforcement, full-suite guard, run guard, and the published-recipe
scan. `ruff check` clean.

E2E: exercised through the real guard subprocesses in both trees on a pinned
environment — control stays BLOCK, obfuscated cells move ALLOW -> ASK, five benign
expansion shapes stay ALLOW — plus the 14-command corpus replay above. Post-merge,
confirm in a live session that ordinary `$VAR`-in-argument work still passes the
push guard without a prompt.
