### PR TITLE
docs(skill): name the six axes review findings actually fall along

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -1501,6 +1501,54 @@ above (full definitions in `.claude/agents/genesis-architect.md`):
   then at the third (escalation cap, `# escalation-ack`). Both call `_deny`, so
   the first stop arrives one round earlier than "the cap" suggests — see the
   two-tier table below. Switch to enumeration BEFORE the gate has to say so.
+- **Interrogate every MECHANISM you introduce along six axes BEFORE the first
+  review — original code and fixes alike.** The two bullets above enumerate the
+  class of a DEFECT, reactively, once a reviewer names one. This one is about the
+  extent of a MECHANISM — a deadline, a lock, a cache, a guard, a token — which is
+  correct on the path that motivated it and undefined everywhere else.
+  MEASURED 2026-09-09 on 31 inline review findings from two PRs, each attributed
+  by `git blame` at the SHA the reviewer was looking at, and classified as
+  "original" or "post-review" by whether the blamed commit predates that PR's
+  first review. Over all rounds, 21 of 31 (68%) blame to the original
+  implementation. But round 1 CANNOT blame to a fix commit — none exists yet — so
+  that figure is partly forced arithmetic. In the rounds that actually loop it is
+  close to even: **of the 21 findings from rounds 2+, 11 were already in the
+  original code and 10 were in code written to answer an earlier round.** Both
+  halves are worth the same attention; neither dominates.
+  Deduplicating re-posts and cross-reviewer duplicates and dropping one finding
+  later refuted by measurement leaves 25 distinct findings, and **24 of those 25
+  fall into six shapes.** These are the checklist:
+  1. **SIGNAL** (8, the largest) — does the thing you read change exactly when
+     the property you assert changes? A whole-database counter read as "did this
+     table change"; an mtime read as "did content change"; empty read as
+     "unbuilt"; a proxy's identity read as "same connection"; two autocommit
+     reads used as one snapshot.
+  2. **SCOPE and LIFETIME** (5) — a deadline per query when the operation is a
+     traversal; a lock per process when the race is cross-process; a lease that
+     expires mid-work; a hang moved from the operation to interpreter teardown.
+  3. **INPUT DOMAIN** (5) — the values the type permits, not the ones you
+     pictured: non-boolean, empty string, malformed timestamp, sub-second
+     precision, unescaped path.
+  4. **EQUIVALENCE** (3) — what does it claim to match, and has anything checked?
+  5. **FAILURE PATH** (2) — what is left behind when the work aborts.
+  6. **CALLER CONTRACT** (1) — does an explicit option the caller passed survive?
+  (The 25th was a test whose identity comparison was unsound in both directions.)
+  A finding is a POINT, so a fix that treats the finding as its spec inherits
+  that point as its only test — which is why the fix half of that near-even split
+  exists at all, and why the six axes are worth running over a fix and not only
+  over a feature.
+  METHOD NOTE, because getting this wrong inverted an earlier version of this
+  measurement: to attribute a finding to a commit, blame the line at the SHA the
+  reviewer was looking at. `original_commit_id` is the PR HEAD when the review was
+  posted, not the introducing commit — one commit here touched only changelog
+  files yet carries three findings on a Python file.
+  FALSIFIABLE, with a denominator: #1850 pushed four commits after its first
+  review round, and deduplicated they carried 5 findings between them — 1.25 per
+  post-review commit. If the next three PRs whose mechanisms are interrogated on
+  these six axes before pushing still average above one deduplicated finding per
+  post-review commit, the axes are not the right ones. Re-derive rather than
+  adding a seventh.
+
 - **Run the pre-push adversarial pass with `/deep-review`** (`.claude/commands/deep-review.md`):
   one command that dispatches a fresh-context `genesis-architect` (+ `genesis-security-reviewer`
   on security surfaces) over the FULL branch diff with the right SHAPE — fail-open/state/TOCTOU/

--- a/changelog.d/20260909170000-changed-fixes-get-their-own-domain-enumerated.md
+++ b/changelog.d/20260909170000-changed-fixes-get-their-own-domain-enumerated.md
@@ -1,0 +1,26 @@
+- **The development skill now names the six axes review findings actually fall
+  along.** Genesis classified 31 review findings from two pull requests,
+  attributing each to the commit that introduced the line it points at. Of the 25
+  distinct findings left after removing duplicates and one that later proved
+  unfounded, 24 fall into six shapes: a signal that does not change when the
+  property it stands for changes; a scope or lifetime narrower than the operation
+  it guards; an input the type permits but nobody pictured; an equivalence
+  claimed but never checked; a failure path that leaves work behind; and a
+  caller's explicit option silently dropped. The 25th was a test whose identity
+  comparison was unsound in both directions. Those six are now a checklist to run
+  against new code before the first review rather than after it.
+
+  The same measurement settled where findings live, which was worth knowing
+  because two successive intuitions about it were both wrong. Counting every
+  round, 21 of the 31 sat in the original implementation — but a first review has
+  no fix code to find anything in, so that number is partly arithmetic. Counting
+  only the rounds that actually loop, it is nearly even: 11 findings were already
+  in the original code and 10 were in code written to answer an earlier round.
+  Neither writing the feature nor answering the review is the dominant source,
+  and the checklist applies to both.
+
+  The entry records what would disprove it, with a rate and a sample size rather
+  than an adjective, and a note on the attribution method — an earlier version of
+  this measurement was inverted by treating a review comment's recorded commit as
+  the commit that introduced the line, when it is the branch head at the moment
+  the review was posted.


### PR DESCRIPTION
The development skill already says to enumerate the class a defect belongs to rather than fixing the named instance. That is reactive — it starts once a reviewer has named something. This adds the proactive half: before the first review, interrogate every mechanism you introduce along the axes where findings have actually landed.

## The six axes

From classifying 31 inline review findings across two pull requests. Of the 25 that remain after removing duplicates and one later refuted by measurement, **24 fall into six shapes**:

| axis | n | what it asks |
|---|---|---|
| **Signal** | 8 | does the thing you read change exactly when the property you assert changes? |
| **Scope / lifetime** | 5 | is the bound the extent of the operation, or of the call you were looking at? |
| **Input domain** | 5 | the values the type permits, not the ones you pictured |
| **Equivalence** | 3 | what does it claim to match, and has anything checked? |
| **Failure path** | 2 | what is left behind when the work aborts |
| **Caller contract** | 1 | does an explicit option the caller passed survive? |

The 25th was a test whose identity comparison was unsound in both directions.

Concrete examples, all real findings: a whole-database counter read as "did this table change"; an mtime read as "did content change"; empty read as "unbuilt"; a proxy's identity read as "same connection"; a deadline per query when the operation is a traversal; a lock per process when the race is cross-process.

## Where findings live — two wrong answers before the right one

Counting every round, 21 of the 31 sat in the original implementation. But **a first review has no fix code to find anything in**, so that figure is partly arithmetic rather than evidence. Counting only the rounds that actually loop, it is nearly even: **11 findings were already in the original code, 10 were in code written to answer an earlier round.** Neither writing the feature nor answering the review dominates — which is why the checklist is aimed at both.

## Method note, which is why this took three attempts

A review comment's `original_commit_id` is the branch head at the moment the review was posted, **not** the commit that introduced the line. One commit in this sample touched only changelog files and still carries three findings on a Python file. Blame the line at the reviewed SHA instead.

Both earlier versions of this text were rejected by adversarial audit, each time on a headline number, and both times the arithmetic was fine while the *instrument* was wrong:

- v1 attributed findings by `original_commit_id` and concluded the opposite of the truth.
- v2 disclosed a filter for reviewer acknowledgements that **removed zero rows** — the bot opens them with a backtick-quoted mention, so `startswith("@Winged")` never matched. A filter that removes nothing reads exactly like a filter that works, which is the failure this rule is about.

The falsifier is stated with a rate and a sample size rather than an adjective: the baseline is 1.25 deduplicated findings per post-review commit, measured over all four of one PR's post-review commits.

## Scope

Documentation only. One bullet in `.claude/skills/genesis-development/SKILL.md`, placed after the two bullets it extends, plus a changelog fragment. No code, no tests, no behaviour change.

Checked against the other open PRs touching this file — #1904, #1903, #1863 hit lines 1524+, 1568+, 1740; this inserts at 1504–1552 and none of them says this.

E2E: none — a prompt-surface documentation change with no runtime surface.
