### PR TITLE
fix(gate): one primitive for superseded concurrency cancels, not two rules

### DIFF
--- a/changelog.d/20260909201859-fixed-superseded-cancel-drop-shared.md
+++ b/changelog.d/20260909201859-fixed-superseded-cancel-drop-shared.md
@@ -1,0 +1,1 @@
+- Merge gate: a duplicated CI dispatch no longer wedges the scheduled-review relief. When one commit carries both a cancelled and a successful run of the same job, the leaks relief now drops the superseded cancel exactly as the CI check already did, so a single `--check-pr` can no longer report CI green while telling you a green job is not green.

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -761,6 +761,80 @@ def _ci_identity(c: dict) -> tuple[str, str] | None:
     return None
 
 
+def _drop_superseded_cancels(checks: list) -> list:
+    """Return *checks* with superseded ``concurrency: cancel-in-progress`` duplicates
+    removed — a CANCELLED CheckRun is dropped ONLY when a SUCCESS of the EXACT same
+    ``(name, workflowName)`` identity completed AT OR AFTER it; every other entry is
+    returned unchanged, in order.
+
+    THE ONE home of that rule. It had two: ``_pr_ci_status`` (which has always
+    applied it) and ``_mechanical_scan_is_green`` (added later, which re-derived a
+    naive ``all(c == "SUCCESS")`` and never handled a cancel at all). A doubled
+    workflow dispatch — two ``pull_request`` runs for one sha, leaving EVERY
+    check-run as a success+cancelled pair — made the two disagree about one payload
+    inside ONE process: ``ci: green`` alongside "'leak-detector' is not green at
+    this head", a message that sends the reader to inspect a job that is green.
+    Deterministic for as long as that head stands, not a flake. Any FUTURE consumer
+    of check-run conclusions calls this rather than re-deriving it a third time.
+
+    Every condition below fails CLOSED — a cancel that cannot be PROVEN superseded
+    is returned, and the caller's own red/not-green logic then sees it:
+
+    * Only GitHub Actions CheckRuns with a resolvable identity AND a ``completedAt``
+      may serve as the superseding sibling (``_ci_identity`` → None for a legacy
+      StatusContext or a non-Actions check; a timestampless SUCCESS is skipped). So
+      a StatusContext SUCCESS can never drop a same-named CheckRun cancel.
+    * A cancel with no identity, no ``completedAt``, or no qualifying success STAYS.
+      That includes SUCCESS-then-cancel on an unchanged head: the latest attempt
+      never passed, so nothing supersedes the cancel.
+    * ONLY ``_CI_CANCEL_CONCLUSIONS`` (deliberately ``{"CANCELLED"}`` alone) is
+      droppable. FAILURE / TIMED_OUT / ACTION_REQUIRED / STARTUP_FAILURE / STALE
+      carry real verdicts and are never dropped, whatever completed beside them —
+      so this can never widen into "ignore anything that is not SUCCESS".
+    * Non-terminal entries (an in-flight re-run) are not conclusions and are never
+      touched; the caller still counts them PENDING.
+    * Entries that are not dicts are passed through untouched, so a caller's own
+      shape checks still see the payload it was given.
+
+    Comparison is a lexicographic string compare of two ISO-8601 ``completedAt``
+    values, both sides terminal COMPLETED runs that always carry one. This is NOT
+    the pulled #1420 finding-magnet, which sorted the WHOLE set (including QUEUED
+    runs with a null ``startedAt``) to pick a global "latest".
+
+    THE ASSUMPTION THAT COMPARE RESTS ON, stated so a future reader knows what would
+    invalidate it: GitHub's GraphQL ``completedAt`` is emitted as second-precision
+    UTC with a literal ``Z`` (OBSERVED on real rollups, e.g. ``2026-09-09T16:20:59Z``;
+    not verified against GitHub's schema docs). Lexicographic ordering equals
+    chronological ordering only while EVERY value shares that one format. Two shapes
+    would break it — a ``+00:00`` offset instead of ``Z``, and fractional seconds
+    (``'Z'`` sorts ABOVE ``'.'``, so a SUCCESS at ``:00Z`` would compare as at-or-after
+    a cancel at ``:00.9Z`` and wrongly drop it). Both are unobserved here. If either
+    ever appears, normalise in BOTH passes before comparing — do not patch one.
+    """
+    # Pass 1: the latest completedAt among SUCCESS runs, per strict identity.
+    success_latest: dict[tuple[str, str], str] = {}
+    for c in checks:
+        if not isinstance(c, dict) or c.get("conclusion") not in _CI_GREEN:
+            continue
+        ident = _ci_identity(c)
+        ts = (c.get("completedAt") or "").strip()
+        if ident is None or not ts:
+            continue
+        if ts > success_latest.get(ident, ""):
+            success_latest[ident] = ts
+
+    # Pass 2: drop only the cancels pass 1 proves superseded.
+    kept: list = []
+    for c in checks:
+        if isinstance(c, dict) and c.get("conclusion") in _CI_CANCEL_CONCLUSIONS:
+            ident = _ci_identity(c)
+            cts = (c.get("completedAt") or "").strip()
+            if ident is not None and cts and success_latest.get(ident, "") >= cts:
+                continue
+        kept.append(c)
+    return kept
+
+
 def _pr_ci_status(pr_num: str, repo: str | None = None) -> tuple[str, list[str]]:
     """Classify a PR's CI check-runs.
 
@@ -771,8 +845,9 @@ def _pr_ci_status(pr_num: str, repo: str | None = None) -> tuple[str, list[str]]
                         A CANCELLED CheckRun that a same (name, workflowName)
                         SUCCESS completed at-or-after is a superseded
                         `concurrency: cancel-in-progress` duplicate and is dropped
-                        (see _ci_identity + success_latest) — strict identity,
-                        terminal completedAt comparison only, fail-closed.
+                        by the SHARED _drop_superseded_cancels helper (see
+                        _ci_identity) — strict identity, terminal completedAt
+                        comparison only, fail-closed.
       * ``"pending"`` — a check is still queued/running (and none are red)
       * ``"absent"``  — a READABLE but genuinely EMPTY rollup (``[]``): zero checks
                         exist, i.e. CI has NOT run. A DEFINITE fact, not a read
@@ -842,26 +917,21 @@ def _pr_ci_status(pr_num: str, repo: str | None = None) -> tuple[str, list[str]]
         # never fired (e.g. a conflicting branch suppresses the whole suite).
         return "absent", []
 
-    # First pass: for each strict identity (name, workflowName), the latest
-    # `completedAt` among its SUCCESS CheckRuns on this head. A CANCELLED entry is
-    # a superseded concurrency-cancel duplicate ONLY if a SUCCESS of the same
-    # identity completed AT OR AFTER it (see the drop branch). Only GitHub Actions
-    # CheckRuns with a resolvable identity AND a completedAt contribute; legacy
-    # StatusContexts, non-Actions checks, and timestampless successes never serve
-    # as siblings. This is NOT the #1420 finding-magnet: that sorted the WHOLE set
-    # (incl. QUEUED runs with null startedAt) to pick a global "latest"; here both
-    # sides of the comparison are terminal COMPLETED runs that always carry a
-    # completedAt, and every unresolvable case fails CLOSED (stays red).
-    success_latest: dict[tuple[str, str], str] = {}
-    for c in checks:
-        if not isinstance(c, dict) or c.get("conclusion") not in _CI_GREEN:
-            continue
-        ident = _ci_identity(c)
-        ts = (c.get("completedAt") or "").strip()
-        if ident is None or not ts:
-            continue
-        if ts > success_latest.get(ident, ""):
-            success_latest[ident] = ts
+    # Drop superseded `concurrency: cancel-in-progress` duplicates via the SHARED
+    # primitive (_drop_superseded_cancels — read its docstring for the strict
+    # identity + at-or-after rule and every fail-closed case). Filtering here rather
+    # than branching inside the classify loop is behaviour-identical: a drop implies
+    # a same-identity SUCCESS in this very list, and that sibling sets
+    # `saw_recognized` and contributes the same casefolded `workflowName` to
+    # `workflows_ran` on its own. A cancel that is NOT dropped falls through to the
+    # red branch below, because CANCELLED is also in _CI_RED_CONCLUSIONS.
+    #
+    # Deliberately AFTER the empty-rollup "absent" return above, which reads the
+    # RAW payload: "zero checks exist" must stay a fact about what GitHub reported,
+    # never an artefact of our own filtering. (The filter cannot empty a non-empty
+    # list anyway — a drop requires a surviving SUCCESS sibling — but the ordering
+    # makes that independent of this helper's behaviour.)
+    checks = _drop_superseded_cancels(checks)
 
     red: list[str] = []
     pending: list[str] = []
@@ -883,30 +953,16 @@ def _pr_ci_status(pr_num: str, repo: str | None = None) -> tuple[str, list[str]]
         if conclusion in _CI_SKIP_CONCLUSIONS:
             saw_recognized = True
             continue
-        if conclusion in _CI_CANCEL_CONCLUSIONS:
-            ident = _ci_identity(c)
-            cts = (c.get("completedAt") or "").strip()
-            if ident is not None and cts and success_latest.get(ident, "") >= cts:
-                # Superseded concurrency-cancel duplicate: a SUCCESS of this EXACT
-                # identity (name + workflowName) completed AT OR AFTER this cancel,
-                # so the cancelled entry is a `cancel-in-progress` leftover with no
-                # verdict of its own — drop it. Wrong-green-impossible:
-                # FAILURE/TIMED_OUT are not in _CI_CANCEL_CONCLUSIONS (still red);
-                # an in-flight re-run is a non-terminal entry that still counts
-                # pending below; and a cancel with no identity, no completedAt, or
-                # NO same-identity success at-or-after it (e.g. SUCCESS-then-cancel
-                # on an unchanged head) falls through and stays red.
-                saw_recognized = True
-                # A superseded duplicate implies a same-identity SUCCESS exists on
-                # this head, so the workflow demonstrably ran.
-                workflows_ran.add(wf_key)
-                continue
+        # Any CANCELLED entry still present here was NOT superseded (the shared
+        # filter above proved it, or could not) and falls through to the red branch,
+        # because CANCELLED is in _CI_RED_CONCLUSIONS. The dropped ones need no arm
+        # of their own: each implies a same-identity SUCCESS in this list, which
+        # sets saw_recognized and adds the identical workflowName to workflows_ran.
         if conclusion in _CI_RED_CONCLUSIONS or state in _CI_RED_STATES:
             saw_recognized = True
             red.append(name)
         elif conclusion in _CI_GREEN or state in _CI_GREEN:
-            # The ONLY branch (besides the superseded-cancel drop above, which implies
-            # a green sibling) that feeds workflows_ran: the required-identity check
+            # The ONLY branch that feeds workflows_ran: the required-identity check
             # runs only when nothing is red/pending (those return first, and already
             # block), so only PASSING verdicts can vouch that a required workflow ran.
             # A COMPLETED run with a null conclusion (the benign ignore below) carries
@@ -4817,9 +4873,13 @@ def _mechanical_scan_is_green(
     class this file already documents at _ci_identity, and the whole point of
     this relief is that the mechanical layer really ran.
 
+    Superseded ``concurrency: cancel-in-progress`` duplicates are dropped first, by
+    the SHARED ``_drop_superseded_cancels`` — the same primitive ``_pr_ci_status``
+    uses, so the two gates cannot disagree about one rollup.
+
     Returns False on ANY doubt: a gh error, an unparseable payload, a head that
-    does not match, no entry with that identity, or any conclusion other than
-    SUCCESS. This feeds a merge gate that forces --admin, so an unreadable or
+    does not match, no entry with that identity, or any surviving conclusion other
+    than SUCCESS. This feeds a merge gate that forces --admin, so an unreadable or
     ambiguous scan must never read as a pass.
 
     Tests inject via ``_TEST_GH_ROLLUP_WITH_HEAD`` (a JSON object with
@@ -4870,6 +4930,20 @@ def _mechanical_scan_is_green(
     wanted_workflow = (workflow or "").strip().lower()
     if not wanted_workflow:
         return False  # an unpinned kind can never be established -> fail closed
+    # Drop superseded `concurrency: cancel-in-progress` duplicates FIRST, through the
+    # SAME primitive the CI gate uses (_drop_superseded_cancels — strict
+    # (name, workflowName) identity, a SUCCESS completing at-or-after, fail-closed on
+    # every unresolvable case). This path used to have no cancel handling at all, so a
+    # doubled workflow dispatch — which leaves every check-run as a success+cancelled
+    # pair — made ONE `--check-pr` run report `ci: green` and, on the same rollup,
+    # "'leak-detector' is not green at this head", pointing the reader at a green job
+    # while relief stayed unreachable for as long as that head stood.
+    #
+    # Note what the drop does NOT do, because this is where it would be dangerous: it
+    # removes ONLY cancels proven superseded. FAILURE/TIMED_OUT/STALE and an
+    # unsuperseded cancel all survive into `conclusions` and still contradict SUCCESS,
+    # so the guarantee below is intact.
+    rollup = _drop_superseded_cancels(rollup)
     # Collect EVERY same-identity entry, never the first match. One head can carry
     # several runs of one job (a re-run after a ruleset change, a superseded
     # concurrency sibling), and rollup ORDER is not a guarantee -- _pr_ci_status

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -715,8 +715,10 @@ _CI_PENDING_STATES = {"PENDING", "EXPECTED"}
 # almost always by a `concurrency: cancel-in-progress` supersession, which leaves
 # the cancelled dup attached to the head commit. It is red BY DEFAULT (it is also
 # in _CI_RED_CONCLUSIONS), and dropped ONLY when a check of the SAME identity
-# (name + workflowName, see _ci_identity) concluded SUCCESS at-or-after it on this
-# head (so a SUCCESS-then-cancel re-run on an unchanged head still blocks).
+# (name + workflowName, see _ci_identity) concluded SUCCESS STRICTLY AFTER it on this
+# head (so a SUCCESS-then-cancel re-run on an unchanged head still blocks, and so does
+# an EQUAL second-precision timestamp, which orders nothing — see
+# _drop_superseded_cancels for why an unprovable ordering fails closed).
 # Deliberately scoped to CANCELLED alone: FAILURE/TIMED_OUT/ACTION_REQUIRED/
 # STARTUP_FAILURE carry real verdicts and always block, even with a success sibling.
 _CI_CANCEL_CONCLUSIONS = {"CANCELLED"}
@@ -764,8 +766,21 @@ def _ci_identity(c: dict) -> tuple[str, str] | None:
 def _drop_superseded_cancels(checks: list) -> list:
     """Return *checks* with superseded ``concurrency: cancel-in-progress`` duplicates
     removed — a CANCELLED CheckRun is dropped ONLY when a SUCCESS of the EXACT same
-    ``(name, workflowName)`` identity completed AT OR AFTER it; every other entry is
+    ``(name, workflowName)`` identity completed STRICTLY AFTER it; every other entry is
     returned unchanged, in order.
+
+    STRICTLY after, not at-or-after. ``completedAt`` is second-precision, so an EQUAL
+    timestamp does not order the two runs at all — it says only that they finished in
+    the same second, which is not evidence that the success came second. On a
+    supersession the successful run STARTS when the cancel fires and finishes a whole
+    job later, so a tie is not even the shape this drop exists to recognise; a tie is
+    far likelier to be two unrelated runs, or a genuinely-cancelled latest attempt.
+    An unprovable ordering therefore fails CLOSED, like every other unresolvable case
+    below. MEASURED before tightening (the Actions runs API over 400 runs / 2 days,
+    30 real cancelled jobs on 25 shas): 18/30 had a strictly-later success, 12/30 had
+    none, and **0/30 turned on a tie** — so this costs nothing observed, and 30 is a
+    small denominator, which is precisely why the direction matters more than the
+    rate: being wrong here over-blocks, it cannot wrong-green.
 
     THE ONE home of that rule. It had two: ``_pr_ci_status`` (which has always
     applied it) and ``_mechanical_scan_is_green`` (added later, which re-derived a
@@ -803,13 +818,17 @@ def _drop_superseded_cancels(checks: list) -> list:
 
     THE ASSUMPTION THAT COMPARE RESTS ON, stated so a future reader knows what would
     invalidate it: GitHub's GraphQL ``completedAt`` is emitted as second-precision
-    UTC with a literal ``Z`` (OBSERVED on real rollups, e.g. ``2026-09-09T16:20:59Z``;
-    not verified against GitHub's schema docs). Lexicographic ordering equals
-    chronological ordering only while EVERY value shares that one format. Two shapes
-    would break it — a ``+00:00`` offset instead of ``Z``, and fractional seconds
-    (``'Z'`` sorts ABOVE ``'.'``, so a SUCCESS at ``:00Z`` would compare as at-or-after
-    a cancel at ``:00.9Z`` and wrongly drop it). Both are unobserved here. If either
-    ever appears, normalise in BOTH passes before comparing — do not patch one.
+    UTC with a literal ``Z`` (MEASURED 2017/2017 entries across 122 PR rollups — every
+    one ``Z``-suffixed with no fractional part). That is an OBSERVATION, not a
+    contract: GitHub's schema documents the ``DateTime`` scalar only as "An ISO-8601
+    encoded UTC date string", which constrains neither sub-second precision nor the
+    offset spelling. Lexicographic ordering equals chronological ordering only while
+    EVERY value shares one format. Two shapes would break it — a ``+00:00`` offset
+    instead of ``Z``, and fractional seconds (``'Z'`` sorts ABOVE ``'.'``, so a SUCCESS
+    at ``:00Z`` would compare as later than a cancel at ``:00.9Z`` and wrongly drop
+    it). Neither is observed here. If either ever appears, PARSE both sides and
+    compare datetimes — in BOTH passes; do not patch one, and do not paper over it
+    with more string rules.
     """
     # Pass 1: the latest completedAt among SUCCESS runs, per strict identity.
     success_latest: dict[tuple[str, str], str] = {}
@@ -829,7 +848,7 @@ def _drop_superseded_cancels(checks: list) -> list:
         if isinstance(c, dict) and c.get("conclusion") in _CI_CANCEL_CONCLUSIONS:
             ident = _ci_identity(c)
             cts = (c.get("completedAt") or "").strip()
-            if ident is not None and cts and success_latest.get(ident, "") >= cts:
+            if ident is not None and cts and success_latest.get(ident, "") > cts:
                 continue
         kept.append(c)
     return kept
@@ -841,9 +860,9 @@ def _pr_ci_status(pr_num: str, repo: str | None = None) -> tuple[str, list[str]]
     Returns ``(state, problem_checks)`` where state is one of:
       * ``"green"``   — every non-skipped check concluded SUCCESS
       * ``"red"``     — at least one check failed/timed-out, or was cancelled
-                        with NO same-identity SUCCESS completing at-or-after it.
+                        with NO same-identity SUCCESS completing STRICTLY AFTER it.
                         A CANCELLED CheckRun that a same (name, workflowName)
-                        SUCCESS completed at-or-after is a superseded
+                        SUCCESS completed strictly after is a superseded
                         `concurrency: cancel-in-progress` duplicate and is dropped
                         by the SHARED _drop_superseded_cancels helper (see
                         _ci_identity) — strict identity, terminal completedAt
@@ -919,7 +938,7 @@ def _pr_ci_status(pr_num: str, repo: str | None = None) -> tuple[str, list[str]]
 
     # Drop superseded `concurrency: cancel-in-progress` duplicates via the SHARED
     # primitive (_drop_superseded_cancels — read its docstring for the strict
-    # identity + at-or-after rule and every fail-closed case). Filtering here rather
+    # identity + strictly-after rule and every fail-closed case). Filtering here rather
     # than branching inside the classify loop is behaviour-identical: a drop implies
     # a same-identity SUCCESS in this very list, and that sibling sets
     # `saw_recognized` and contributes the same casefolded `workflowName` to
@@ -4173,6 +4192,25 @@ _IRREDUCIBLE_REQUIRED_SCHEDULED_REVIEW_KINDS = ("leaks",)
 # travel with a clone rather than describing one install. A suite named differently
 # simply finds no match, and no match means NO RELIEF -- the pre-relief behaviour, so
 # the failure direction of a wrong pin is a missing convenience, never a weaker gate.
+#
+# THE WORKFLOW HALF IS A DISPLAY NAME, AND A DISPLAY NAME IS NOT UNIQUE PROVENANCE.
+# GitHub does not require `name:` to be unique across workflow files (its workflow-syntax
+# reference states no such constraint; an OMITTED name falls back to the file path, which
+# is unique — an explicit one is not). So a second file declaring `name: CI` with a job
+# named `leak-detector` would share this tuple, and its SUCCESS could both supersede the
+# real scanner's CANCELLED in _drop_superseded_cancels and satisfy the pin below.
+# Real provenance exists in GraphQL (checkSuite.workflowRun.workflow.databaseId, or
+# checkSuite.workflowRun.file.path) but `gh pr view --json statusCheckRollup` does NOT
+# expose it — a rollup entry carries only __typename/completedAt/conclusion/detailsUrl/
+# name/startedAt/status/workflowName, and detailsUrl's RUN id cannot separate a decoy
+# from a legitimate re-run of the same file. Pinning on provenance therefore means
+# replacing this gate's read path with a raw GraphQL query.
+# Until then the PRECONDITION is closed instead of the consequence:
+# TestWorkflowDisplayNameIsUniqueProvenance fails CI if two workflow files ever share a
+# display name, or if this pin stops resolving to exactly one file. That is complete for
+# the reachable case — workflowName is populated only for Actions check-runs, and those
+# come from this repo's own workflow files; a non-Actions check-run has no workflowName,
+# so _ci_identity returns None and it is never a sibling.
 _MECHANICAL_RESCAN_BY_KIND = {"leaks": ("leak-detector", "CI")}
 # Every kind an install is ALLOWED to name in config. A configured kind outside this set
 # (a typo, a wrong type, a stale routine name) can never be satisfied by a real marker, so
@@ -4932,7 +4970,7 @@ def _mechanical_scan_is_green(
         return False  # an unpinned kind can never be established -> fail closed
     # Drop superseded `concurrency: cancel-in-progress` duplicates FIRST, through the
     # SAME primitive the CI gate uses (_drop_superseded_cancels — strict
-    # (name, workflowName) identity, a SUCCESS completing at-or-after, fail-closed on
+    # (name, workflowName) identity, a SUCCESS completing STRICTLY AFTER, fail-closed on
     # every unresolvable case). This path used to have no cancel handling at all, so a
     # doubled workflow dispatch — which leaves every check-run as a success+cancelled
     # pair — made ONE `--check-pr` run report `ci: green` and, on the same rollup,

--- a/tests/test_hooks/test_leaks_gate_mechanical_rescan.py
+++ b/tests/test_hooks/test_leaks_gate_mechanical_rescan.py
@@ -477,6 +477,302 @@ class TestDuplicateRollupEntries:
         assert _gate() is None
 
 
+# ── Superseded concurrency cancels (the shared _drop_superseded_cancels primitive) ──
+#
+# A doubled workflow dispatch (two `pull_request` runs for one sha) leaves EVERY
+# check-run on the head as a success+cancelled PAIR. _pr_ci_status has always
+# dropped the superseded cancel; this relief path was added later and re-derived a
+# naive `all(c == "SUCCESS")`, so the SAME rollup read `ci: green` and
+# `leak-detector is not green at this head` in ONE --check-pr run. That is not a
+# flake: on a doubled dispatch the relief is unreachable DETERMINISTICALLY for as
+# long as the head stands, and the block message points the reader at a job that
+# is green. Both consumers now call one helper.
+#
+# Times below are ISO-8601 Z strings, compared lexicographically exactly as the
+# helper does. CANCEL_AT precedes SUCCESS_AT.
+CANCEL_AT = "2026-09-09T16:20:59Z"
+SUCCESS_AT = "2026-09-09T16:21:59Z"
+LATER_AT = "2026-09-09T16:30:00Z"
+
+
+def _run(conclusion, *, name="leak-detector", workflow="CI", completed_at=None):
+    entry = {
+        "name": name,
+        "workflowName": workflow,
+        "status": "COMPLETED",
+        "conclusion": conclusion,
+    }
+    if completed_at is not None:
+        entry["completedAt"] = completed_at
+    return entry
+
+
+def _rollup_entries(*entries, head=HEAD):
+    return json.dumps({"headRefOid": head, "statusCheckRollup": list(entries)})
+
+
+class TestSupersededConcurrencyCancels:
+    """The relief path must drop a superseded `cancel-in-progress` duplicate on the
+    SAME terms as _pr_ci_status — and on no looser terms. Dropping superseded
+    cancels must never become 'ignore anything that is not SUCCESS'."""
+
+    def test_doubled_dispatch_pair_relieves(self, monkeypatch):
+        """ACCEPTANCE BAR — the real PR #1839 shape, replayed.
+
+        Its head carried leak-detector CANCELLED(16:20:59) + SUCCESS(16:21:59)
+        under one identity, for 13+ identities. Relief was declined with
+        'leak-detector is not green at this head' while the CI gate on the very
+        same rollup reported green.
+        """
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
+        monkeypatch.setenv(
+            "_TEST_GH_ROLLUP_WITH_HEAD",
+            _rollup_entries(
+                _run("CANCELLED", completed_at=CANCEL_AT),
+                _run("SUCCESS", completed_at=SUCCESS_AT),
+            ),
+        )
+        assert _gate() is None
+
+    def test_many_paired_identities_relieve(self, monkeypatch):
+        """The real shape is not one pair: a doubled dispatch pairs EVERY job.
+        Unrelated identities' pairs must neither block nor license the scanner."""
+        entries = []
+        for job in ("test", "lint", "leak-detector", "portability", "changelog"):
+            entries.append(_run("CANCELLED", name=job, completed_at=CANCEL_AT))
+            entries.append(_run("SUCCESS", name=job, completed_at=SUCCESS_AT))
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup_entries(*entries))
+        assert _gate() is None
+
+    def test_cancel_with_no_success_sibling_blocks(self, monkeypatch):
+        """A genuine cancel — the scanner never produced a verdict at this head."""
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
+        monkeypatch.setenv(
+            "_TEST_GH_ROLLUP_WITH_HEAD",
+            _rollup_entries(_run("CANCELLED", completed_at=CANCEL_AT)),
+        )
+        msg = _gate()
+        assert msg and "leaks" in msg
+
+    def test_success_then_cancel_on_unchanged_head_blocks(self, monkeypatch):
+        """The LATEST attempt never passed: the cancel is not superseded."""
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
+        monkeypatch.setenv(
+            "_TEST_GH_ROLLUP_WITH_HEAD",
+            _rollup_entries(
+                _run("SUCCESS", completed_at=CANCEL_AT),
+                _run("CANCELLED", completed_at=SUCCESS_AT),
+            ),
+        )
+        msg = _gate()
+        assert msg and "leaks" in msg
+
+    def test_cancel_without_completedat_blocks(self, monkeypatch):
+        """Fail-closed: with no timestamp the cancel cannot be ORDERED against the
+        success, so it is not provably superseded."""
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
+        monkeypatch.setenv(
+            "_TEST_GH_ROLLUP_WITH_HEAD",
+            _rollup_entries(
+                _run("CANCELLED"),
+                _run("SUCCESS", completed_at=SUCCESS_AT),
+            ),
+        )
+        msg = _gate()
+        assert msg and "leaks" in msg
+
+    def test_timestampless_success_cannot_supersede(self, monkeypatch):
+        """The superseding sibling needs a completedAt of its own."""
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
+        monkeypatch.setenv(
+            "_TEST_GH_ROLLUP_WITH_HEAD",
+            _rollup_entries(
+                _run("CANCELLED", completed_at=CANCEL_AT),
+                _run("SUCCESS"),
+            ),
+        )
+        msg = _gate()
+        assert msg and "leaks" in msg
+
+    def test_dropping_a_cancel_does_not_launder_a_failure(self, monkeypatch):
+        """THE GUARANTEE THIS PATH MUST KEEP. Under `# ci-override` this relief is
+        the only remaining check of the mechanical layer, so a SUCCESS-then-FAILURE
+        pair must still read red even when a superseded cancel is dropped beside
+        it. FAILURE is not in the cancel set and is never dropped."""
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
+        monkeypatch.setenv(
+            "_TEST_GH_ROLLUP_WITH_HEAD",
+            _rollup_entries(
+                _run("CANCELLED", completed_at=CANCEL_AT),
+                _run("SUCCESS", completed_at=SUCCESS_AT),
+                _run("FAILURE", completed_at=LATER_AT),
+            ),
+        )
+        msg = _gate()
+        assert msg and "leaks" in msg
+
+    @pytest.mark.parametrize(
+        "conclusion",
+        # The COMPLETE set: _CI_RED_CONCLUSIONS minus CANCELLED. This test exists to
+        # stop the DROPPABLE set widening, so it must enumerate every member the
+        # constant holds, not a sample of them.
+        ["FAILURE", "TIMED_OUT", "ACTION_REQUIRED", "STARTUP_FAILURE", "STALE"],
+    )
+    def test_only_cancelled_is_droppable(self, monkeypatch, conclusion):
+        """Scope lock on _CI_CANCEL_CONCLUSIONS: every other non-green terminal
+        conclusion carries a real verdict and survives a later same-identity
+        success. STALE is a real GitHub conclusion, and it is red, not a pass."""
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
+        monkeypatch.setenv(
+            "_TEST_GH_ROLLUP_WITH_HEAD",
+            _rollup_entries(
+                _run(conclusion, completed_at=CANCEL_AT),
+                _run("SUCCESS", completed_at=SUCCESS_AT),
+            ),
+        )
+        msg = _gate()
+        assert msg and "leaks" in msg
+
+    def test_same_named_decoy_from_another_workflow_cannot_supersede(self, monkeypatch):
+        """Identity is (name, workflowName). A success published by a DIFFERENT
+        workflow under the scanner's display name must not drop the real cancel."""
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
+        monkeypatch.setenv(
+            "_TEST_GH_ROLLUP_WITH_HEAD",
+            _rollup_entries(
+                _run("CANCELLED", completed_at=CANCEL_AT),
+                _run("SUCCESS", workflow="Decoy", completed_at=SUCCESS_AT),
+            ),
+        )
+        msg = _gate()
+        assert msg and "leaks" in msg
+
+    def test_cancel_survives_when_the_pair_is_entirely_dropped(self, monkeypatch):
+        """A rollup whose ONLY scanner entry is a droppable cancel is impossible by
+        construction (a drop implies a SUCCESS sibling), but the reader must still
+        never treat 'no surviving entry' as a pass."""
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
+        monkeypatch.setenv(
+            "_TEST_GH_ROLLUP_WITH_HEAD",
+            _rollup_entries(_run("SUCCESS", name="unrelated", completed_at=SUCCESS_AT)),
+        )
+        msg = _gate()
+        assert msg and "leaks" in msg
+
+
+class TestBothConsumersAgree:
+    """The anti-drift lock. The defect was not that either path was wrong on its own
+    terms — it was that ONE process reading ONE payload returned opposite verdicts,
+    because the drop logic existed twice. These assert the two consumers against the
+    SAME rollup, so a future divergence fails here rather than in production."""
+
+    _SCANNER = ("leak-detector", "CI")
+
+    def _both(self, monkeypatch, *entries):
+        rollup = list(entries)
+        monkeypatch.setenv("_TEST_GH_CI_ROLLUP", json.dumps(rollup))
+        monkeypatch.setenv("_TEST_REQUIRED_CI_WORKFLOWS", "CI")
+        monkeypatch.setenv(
+            "_TEST_GH_ROLLUP_WITH_HEAD",
+            json.dumps({"headRefOid": HEAD, "statusCheckRollup": rollup}),
+        )
+        ci_state, _ = _mod._pr_ci_status("1", repo="acme/pub")
+        scanner = _mod._mechanical_scan_is_green("1", HEAD, *self._SCANNER, repo="acme/pub")
+        return ci_state, scanner
+
+    def test_superseded_cancel_is_green_to_both(self, monkeypatch):
+        ci_state, scanner = self._both(
+            monkeypatch,
+            _run("CANCELLED", completed_at=CANCEL_AT),
+            _run("SUCCESS", completed_at=SUCCESS_AT),
+        )
+        assert (ci_state, scanner) == ("green", True)
+
+    def test_unsuperseded_cancel_is_red_to_both(self, monkeypatch):
+        ci_state, scanner = self._both(
+            monkeypatch,
+            _run("SUCCESS", completed_at=CANCEL_AT),
+            _run("CANCELLED", completed_at=SUCCESS_AT),
+        )
+        assert (ci_state, scanner) == ("red", False)
+
+    def test_failure_beside_a_dropped_cancel_is_red_to_both(self, monkeypatch):
+        ci_state, scanner = self._both(
+            monkeypatch,
+            _run("CANCELLED", completed_at=CANCEL_AT),
+            _run("SUCCESS", completed_at=SUCCESS_AT),
+            _run("FAILURE", completed_at=LATER_AT),
+        )
+        assert (ci_state, scanner) == ("red", False)
+
+
+class TestDropSupersededCancelsUnit:
+    """_drop_superseded_cancels in isolation: it filters, and nothing else."""
+
+    def test_non_dict_entries_are_preserved(self):
+        payload = ["junk", None, _run("SUCCESS", completed_at=SUCCESS_AT)]
+        assert _mod._drop_superseded_cancels(payload) == payload
+
+    def test_only_the_superseded_cancel_is_removed(self):
+        cancel = _run("CANCELLED", completed_at=CANCEL_AT)
+        success = _run("SUCCESS", completed_at=SUCCESS_AT)
+        other = _run("FAILURE", name="lint", completed_at=LATER_AT)
+        assert _mod._drop_superseded_cancels([cancel, success, other]) == [success, other]
+
+    def test_equal_timestamps_drop(self):
+        """AT OR AFTER: a success completing in the same second supersedes."""
+        cancel = _run("CANCELLED", completed_at=SUCCESS_AT)
+        success = _run("SUCCESS", completed_at=SUCCESS_AT)
+        assert _mod._drop_superseded_cancels([cancel, success]) == [success]
+
+    def test_decoy_workflow_cannot_supersede(self):
+        """Identity is (name, workflowName). Locked AT THE PRIMITIVE, not only at its
+        callers: both of them independently filter by workflow, so a name-only
+        identity is invisible from either call site (verified by mutation — the
+        callers' own filters mask it) while still being wrong for the next consumer.
+        """
+        cancel = _run("CANCELLED", completed_at=CANCEL_AT)
+        decoy = _run("SUCCESS", workflow="Decoy", completed_at=SUCCESS_AT)
+        assert _mod._drop_superseded_cancels([cancel, decoy]) == [cancel, decoy]
+
+    def test_statuscontext_success_cannot_supersede(self):
+        """A legacy StatusContext (no workflowName ⇒ no identity) is never a sibling."""
+        cancel = _run("CANCELLED", completed_at=CANCEL_AT)
+        legacy = {"context": "leak-detector", "state": "SUCCESS", "completedAt": SUCCESS_AT}
+        assert _mod._drop_superseded_cancels([cancel, legacy]) == [cancel, legacy]
+
+    def test_timestampless_success_cannot_supersede(self):
+        """The sibling needs a completedAt of its own — there is no ordering without
+        one, and an unordered pair is not proof of supersession."""
+        cancel = _run("CANCELLED", completed_at=CANCEL_AT)
+        success = _run("SUCCESS")
+        assert _mod._drop_superseded_cancels([cancel, success]) == [cancel, success]
+
+    def test_scope_lock_enumerates_every_non_cancel_red_conclusion(self):
+        """DERIVED-SET GUARD. `test_only_cancelled_is_droppable` is the test that stops
+        the droppable set widening, so its parametrize must equal
+        `_CI_RED_CONCLUSIONS - _CI_CANCEL_CONCLUSIONS` — the WHOLE set, not a sample.
+        Without this, a conclusion added to the constant ships untested and the scope
+        lock silently covers less than it claims. (STARTUP_FAILURE was missing from the
+        first draft of that list; a reviewer caught it, which is precisely the kind of
+        arithmetic a test should be doing instead.)"""
+        marks = TestSupersededConcurrencyCancels.test_only_cancelled_is_droppable.pytestmark
+        parametrized = [m for m in marks if m.name == "parametrize"]
+        assert len(parametrized) == 1, "expected exactly one parametrize mark to read"
+        covered = set(parametrized[0].args[1])
+        assert covered == set(_mod._CI_RED_CONCLUSIONS) - set(_mod._CI_CANCEL_CONCLUSIONS)
+
+    def test_input_is_not_mutated(self):
+        entries = [
+            _run("CANCELLED", completed_at=CANCEL_AT),
+            _run("SUCCESS", completed_at=SUCCESS_AT),
+        ]
+        before = json.dumps(entries)
+        _mod._drop_superseded_cancels(entries)
+        assert json.dumps(entries) == before
+
+
 class TestCandidateSelection:
     """Any accepted ancestor will do. Nothing rests on WHICH one is carried: the safety
     argument is the per-head mechanical scan, never the age of the carried review (the

--- a/tests/test_hooks/test_leaks_gate_mechanical_rescan.py
+++ b/tests/test_hooks/test_leaks_gate_mechanical_rescan.py
@@ -648,6 +648,22 @@ class TestSupersededConcurrencyCancels:
         msg = _gate()
         assert msg and "leaks" in msg
 
+    def test_equal_timestamp_cancel_blocks_relief(self, monkeypatch):
+        """The tie rule AT THE GATE, not only at the primitive. This is the cell Codex's
+        P1 named: a genuine cancellation in the same second as a success would, under
+        `>=`, let an OLD leaks review be carried forward while the latest scanner
+        attempt was in fact cancelled."""
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
+        monkeypatch.setenv(
+            "_TEST_GH_ROLLUP_WITH_HEAD",
+            _rollup_entries(
+                _run("CANCELLED", completed_at=SUCCESS_AT),
+                _run("SUCCESS", completed_at=SUCCESS_AT),
+            ),
+        )
+        msg = _gate()
+        assert msg and "leaks" in msg
+
     def test_cancel_survives_when_the_pair_is_entirely_dropped(self, monkeypatch):
         """A rollup whose ONLY scanner entry is a droppable cancel is impossible by
         construction (a drop implies a SUCCESS sibling), but the reader must still
@@ -697,6 +713,17 @@ class TestBothConsumersAgree:
         )
         assert (ci_state, scanner) == ("red", False)
 
+    def test_equal_timestamp_cancel_is_red_to_both(self, monkeypatch):
+        """The tie rule must be the SAME rule on both sides. If a future edit relaxed
+        the boundary in one consumer only, this is where the two would part company —
+        which is the exact failure class this PR exists to remove."""
+        ci_state, scanner = self._both(
+            monkeypatch,
+            _run("CANCELLED", completed_at=SUCCESS_AT),
+            _run("SUCCESS", completed_at=SUCCESS_AT),
+        )
+        assert (ci_state, scanner) == ("red", False)
+
     def test_failure_beside_a_dropped_cancel_is_red_to_both(self, monkeypatch):
         ci_state, scanner = self._both(
             monkeypatch,
@@ -720,9 +747,24 @@ class TestDropSupersededCancelsUnit:
         other = _run("FAILURE", name="lint", completed_at=LATER_AT)
         assert _mod._drop_superseded_cancels([cancel, success, other]) == [success, other]
 
-    def test_equal_timestamps_drop(self):
-        """AT OR AFTER: a success completing in the same second supersedes."""
+    def test_equal_timestamps_do_not_drop(self):
+        """STRICTLY AFTER: an EQUAL second-precision timestamp orders nothing, so it is
+        not evidence the success came second — and on a real supersession the successful
+        run starts when the cancel fires and finishes a whole job later, so a tie is not
+        even the shape this drop recognises. Unprovable ordering fails CLOSED.
+
+        (Codex P1. The `>=` was INHERITED from the working CI path, where 'at or after'
+        was deliberate wording; the extraction gave it a second caller — the relief
+        path — where the consequence is granting relief, and under `# ci-override` that
+        relief is the only remaining check of the mechanical layer.)"""
         cancel = _run("CANCELLED", completed_at=SUCCESS_AT)
+        success = _run("SUCCESS", completed_at=SUCCESS_AT)
+        assert _mod._drop_superseded_cancels([cancel, success]) == [cancel, success]
+
+    def test_strictly_later_success_still_drops(self):
+        """CONTROL for the tie rule: tightening the boundary must not blind the drop.
+        One second later is still a supersession (the #1839 pair was 60s apart)."""
+        cancel = _run("CANCELLED", completed_at=CANCEL_AT)
         success = _run("SUCCESS", completed_at=SUCCESS_AT)
         assert _mod._drop_superseded_cancels([cancel, success]) == [success]
 
@@ -771,6 +813,89 @@ class TestDropSupersededCancelsUnit:
         before = json.dumps(entries)
         _mod._drop_superseded_cancels(entries)
         assert json.dumps(entries) == before
+
+
+class TestWorkflowDisplayNameIsUniqueProvenance:
+    """Codex P1: `(name, workflowName)` is only unique provenance while no two workflow
+    FILES share one display name — and GitHub does not require that.
+
+    ESTABLISHED, not assumed. GitHub's workflow-syntax reference documents `name:` as
+    "The name of the workflow. GitHub displays the names of your workflows under your
+    repository's Actions tab. If you omit name, GitHub displays the workflow file path
+    relative to the root of the repository." No uniqueness constraint is stated
+    anywhere on that page, so two files CAN both declare `name: CI`.
+
+    Why that matters HERE specifically: a decoy file named `CI` publishing a job named
+    `leak-detector` would share the scanner's tuple, so its SUCCESS could supersede the
+    real scanner's CANCELLED in `_drop_superseded_cancels` AND then satisfy the pin in
+    `_mechanical_scan_is_green`. Before this PR the relief path had no drop at all, so
+    both entries were collected and the cancel blocked; the extraction is what makes a
+    decoy able to erase a real cancellation. That widening is real and it is why this
+    guard exists.
+
+    Unique provenance DOES exist in GitHub's GraphQL schema —
+    `checkSuite.workflowRun.workflow.databaseId` and `checkSuite.workflowRun.file.path`
+    — but `gh pr view --json statusCheckRollup` does NOT expose it. MEASURED: a rollup
+    entry carries exactly `__typename, completedAt, conclusion, detailsUrl, name,
+    startedAt, status, workflowName`. `detailsUrl` embeds a RUN id, which is unique per
+    run but does not identify the workflow FILE — two runs of the same file also differ
+    — so it cannot separate a decoy from a legitimate re-run without a second API call.
+    Pinning on real provenance therefore means abandoning `gh pr view --json` for a raw
+    GraphQL query: a rewrite of this gate's read path, not a fix inside this PR.
+
+    So this guard closes the PRECONDITION instead of the consequence, which is cheap and
+    complete for the reachable case: `workflowName` is populated only for GitHub Actions
+    check-runs, and Actions check-runs on this repo's commits come from this repo's own
+    workflow files. A non-Actions app's check-run has no workflowName, so `_ci_identity`
+    returns None and it can never be a sibling. Note `.github/workflows/` is NOT on the
+    hook surface (`_HOOK_SURFACE_PREFIXES`), so a new workflow file gets no extra review
+    — this test is the only thing that would catch the collision."""
+
+    _WORKFLOW_DIR = _WORKTREE / ".github" / "workflows"
+
+    def _display_names(self) -> dict[str, list[str]]:
+        import yaml
+
+        names: dict[str, list[str]] = {}
+        for path in sorted(self._WORKFLOW_DIR.glob("*.y*ml")):
+            try:
+                doc = yaml.safe_load(path.read_text()) or {}
+            except yaml.YAMLError as exc:  # a malformed workflow is its own failure
+                pytest.fail(f"{path.name} is not parseable YAML: {exc}")
+            # An omitted `name:` makes GitHub display the file path, which is unique by
+            # construction — so those cannot collide and are not tracked.
+            declared = doc.get("name") if isinstance(doc, dict) else None
+            if isinstance(declared, str) and declared.strip():
+                names.setdefault(declared.strip(), []).append(path.name)
+        return names
+
+    def test_workflow_dir_exists_and_has_named_workflows(self):
+        """Guard-the-guard: a glob that matches nothing would make every assertion below
+        vacuously true, and this test would then pass while proving nothing."""
+        assert self._WORKFLOW_DIR.is_dir(), f"{self._WORKFLOW_DIR} missing"
+        assert self._display_names(), "no workflow declares a `name:` — guard is vacuous"
+
+    def test_no_two_workflow_files_share_a_display_name(self):
+        collisions = {n: f for n, f in self._display_names().items() if len(f) > 1}
+        assert not collisions, (
+            "Two workflow files share one display name, so `(name, workflowName)` is no "
+            "longer unique provenance and a job in one can supersede a same-named job "
+            f"in the other inside the merge gate: {collisions}. Rename one, or teach "
+            "_mechanical_scan_is_green to pin on real provenance (GraphQL "
+            "checkSuite.workflowRun.file.path) instead of the display name."
+        )
+
+    def test_the_pinned_scanner_workflow_resolves_to_exactly_one_file(self):
+        """The pin is a display NAME. Assert it names exactly one file, for every kind
+        in _MECHANICAL_RESCAN_BY_KIND — so adding a kind cannot skip this check."""
+        names = self._display_names()
+        assert _mod._MECHANICAL_RESCAN_BY_KIND, "no kinds pinned — guard is vacuous"
+        for kind, (check_name, workflow) in _mod._MECHANICAL_RESCAN_BY_KIND.items():
+            files = names.get(workflow, [])
+            assert len(files) == 1, (
+                f"kind {kind!r} pins check {check_name!r} to workflow {workflow!r}, "
+                f"which resolves to {files or 'NO file'} — the pin must name exactly one."
+            )
 
 
 class TestCandidateSelection:

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -3178,12 +3178,19 @@ class TestRequiredCiWorkflowsConfig:
 
 class TestPrCiStatusCancelSibling:
     """Concurrency-cancel dedup (approach B): a CANCELLED CheckRun is dropped IFF a
-    check of the SAME identity (name + workflowName) concluded SUCCESS AT OR AFTER
+    check of the SAME identity (name + workflowName) concluded SUCCESS STRICTLY AFTER
     it — so a superseded `cancel-in-progress` duplicate (cancel older than its
     re-run's success) drops, but a SUCCESS-then-cancel re-run on an unchanged head
     still blocks. Both sides are terminal COMPLETED runs (always carry completedAt);
-    every unresolvable case (no identity, no completedAt, no later success) fails
-    closed to red."""
+    every unresolvable case (no identity, no completedAt, no strictly-later success)
+    fails closed to red.
+
+    The rule now lives in the SHARED `_drop_superseded_cancels`, which the leaks relief
+    path also calls. The boundary was tightened from at-or-after to strictly-after when
+    that second caller appeared (Codex P1): an EQUAL second-precision timestamp orders
+    nothing, and an unprovable ordering must fail closed on a gate that forces --admin.
+    Measured cost on the CI path before tightening: 0 of 30 real cancelled jobs turned
+    on a tie."""
 
     @staticmethod
     def _set(monkeypatch, checks):


### PR DESCRIPTION
## The defect

`scripts/hooks/git_push_guard.py` had **two** independent consumers of GitHub
check-run conclusions, and only one of them handled a cancelled run.

1. **`_pr_ci_status`** — correct. It keeps the latest `completedAt` among SUCCESS runs
   per strict `(name, workflowName)` identity, and drops a `CANCELLED` entry only when
   a SUCCESS of that exact identity completed **at or after** it — a superseded
   `concurrency: cancel-in-progress` duplicate, carrying no verdict of its own.
2. **`_mechanical_scan_is_green`** — the leaks scheduled-review relief, added later. It
   re-derived the naive conjunction: append every same-identity conclusion, return
   `all(c == "SUCCESS")`. No cancel handling at all.

A doubled workflow dispatch leaves **every** check-run on the head as a
success+cancelled pair. One process, one payload, opposite verdicts — measured on
PR #1839 (head `187a80961327`), from a single `--check-pr` run:

```
ci             : green
scheduled-claude: BLOCK ... (relief for 'leaks' was attempted and declined: an earlier
   accepted review exists, but 'leak-detector' is not green at this head (pending,
   failed, absent, or unreadable) -- check that job rather than re-running the
   scheduled review.)
```

The live rollup for that head:

```
leak-detector  CI  COMPLETED  CANCELLED  2026-09-09T16:20:59Z
leak-detector  CI  COMPLETED  SUCCESS    2026-09-09T16:21:59Z
```

This is not an occasional flake. On a doubled dispatch the relief is unreachable
**deterministically**, for as long as that head stands, and the block message
misdirects — it tells the reader to check a job that is green. The failure is
fail-closed (a stall, never a bypass), so it is not a security defect.

## The fix

Extract `_drop_superseded_cancels(checks) -> list` as the **one** home of the rule, and
have both paths call it — rather than transplanting the logic into the relief path. A
copy leaves two rules to drift, and the next consumer of check-run conclusions would get
it wrong the same way.

- `git_push_guard.py:764` — the new primitive.
- `:934` — call site 1, `_pr_ci_status`. The inline drop branch is deleted; the filter
  runs over the rollup instead. Behaviour-identical, because a drop implies a
  same-identity SUCCESS **in the same list**, and that sibling sets `saw_recognized` and
  contributes the identical casefolded `workflowName` to `workflows_ran` on its own.
  The filter sits deliberately **after** the empty-rollup `absent` return, so "zero
  checks exist" stays a fact about what GitHub reported rather than an artefact of our
  filtering.
- `:4946` — call site 2, `_mechanical_scan_is_green`. The filter runs before the
  identity-matched collection loop.

## Properties preserved (each locked by a test)

- Strict `(name, workflowName)` identity — a same-named decoy from another workflow
  cannot supersede.
- **At or after** on terminal `completedAt`, both sides COMPLETED runs.
- Only `CANCELLED` is droppable. `FAILURE` / `TIMED_OUT` / `ACTION_REQUIRED` /
  `STARTUP_FAILURE` / `STALE` stay red beside a later same-identity success.
- A cancel with no identity, no `completedAt`, or no qualifying success stays red.
- A timestampless SUCCESS, a legacy StatusContext, and a non-Actions check are never
  siblings.
- An in-flight re-run is non-terminal and still counts PENDING.
- The relief path keeps its own guarantee — at least one SUCCESS of the pinned identity
  and **no surviving entry that contradicts it**. That matters because under
  `# ci-override` this relief is the only remaining check of the mechanical layer, so
  dropping superseded cancels must not become "ignore anything that is not SUCCESS".

## Verification

**Regression first.** Targeted suites before the change: **734 passed**. After:
**759 passed** (734 + 25 new), 0 failed. The 11 pre-existing
`TestPrCiStatusCancelSibling` tests — the CI path's own cancel suite — pass **unchanged
and unedited**.

**The control.** `TestBothConsumersAgree::test_superseded_cancel_is_green_to_both` drives
one rollup into both consumers and asserts the pair. On the unfixed tree it fails with:

```
AssertionError: assert ('green', False) == ('green', True)
```

which is the defect in one line. It cannot pass without the fix.

**Verify-RED.** 7 hash-gated mutations, zero survivors. Each proved applied (sha256
before/after + `compile()` with the file's own parser), the runner aborts if pytest emits
no result line, and every restore is hash-verified against what the mutation wrote:
at-or-after → strictly-after; cancel set widened to any non-green; identity relaxed to
bare name; each call site removed independently; timestampless success admitted as a
sibling; and the scope-lock list drifted from its constant. Two mutations survived the
first sweep and were **diagnosed rather than explained away** — both behaviourally null.
Re-diagnosing one exposed a real coverage gap: both call sites filter by workflow
themselves, so a name-only identity key is invisible from either one. It is now locked at
the primitive, where the next consumer will meet it.

**Empirically, on the real case.** `--check-pr 1839`, before and after:

```
before:  ci: green   |  scheduled-claude: BLOCK ... 'leak-detector' is not green at this head
after:   ci: green   |  scheduled-claude: ok (leaks carried from d9d441fddbf6, leak-detector green at head)
```

The one gate still blocking #1839 is its stale Codex review, which is unrelated.

## Scope

The double dispatch itself (two `pull_request` runs for one sha in the same second, both
`run_attempt=1`; a shared branch and re-runs both ruled out) is **not** investigated here
and is being chased separately. The gate must tolerate duplicate check-runs regardless of
why they appear — concurrency cancels happen for other reasons too.

**Found but not fixed here:** `src/genesis/outreach/morning_report.py:184
_summarize_ci_rollup` is a third consumer of the same rule, with `CANCELLED` in its
`_FAIL` set and no supersession handling, so on a doubled dispatch it reports a fully
green PR as "failing". It is a report, not a gate; the PR works without it, and importing
a hook module into the runtime would be bad coupling. Flagged for a separate issue.

E2E: replay `python3 scripts/hooks/git_push_guard.py --check-pr <N>` against a PR whose
head carries a success+cancelled pair for `leak-detector` (e.g. #1839 at
`187a809613276be99678f6c299b0cee928ff2b94`) and confirm ONE run reports `ci: green` and
grants the leaks relief, rather than reporting green while declining relief on the same
rollup.

---

# Round 2 — two Codex P1s, both verified and answered

## P1-A: equal-timestamp cancellations no longer supersede

`completedAt` is second-precision, so an EQUAL timestamp does not order two runs. The
`>=` was **inherited** from the CI path, where "at or after" was deliberate; the
extraction gave that rule a second caller where the consequence is granting relief — and
under `# ci-override` that relief is the only remaining check of the mechanical layer.

Two arguments, and the second does not depend on a measurement:

- **Semantic.** On a real `cancel-in-progress` supersession the successful run *starts*
  when the cancel fires and finishes a whole job later. A tie would mean the success
  started first — not the supersession shape at all.
- **Directional.** An unprovable ordering fails closed, as every other unresolvable case
  in the same function already does. Being wrong about the tie rate now over-blocks;
  under `>=` it wrong-greens. Not symmetric.

**Measured cost to the CI path** (the thing at risk), via the Actions runs API — 400
runs over 2 days, 25 of 27 cancel-bearing shas probed:

| outcome for a real CANCELLED job | n / 30 | effect of the change |
|---|---|---|
| SUCCESS strictly later | 18 (60.00%) | dropped by `>=` **and** `>` — unchanged |
| SUCCESS **equal** (a tie) | **0 (0.00%)** | the only cell that changes |
| no qualifying SUCCESS | 12 (40.00%) | kept by both — unchanged |

Zero observed cancelled jobs change verdict. 30 is a small denominator (rule-of-three
95% upper bound ≈10%), which is exactly why the direction carries the argument.
**Falsifier:** a measured population of ties where the SUCCESS is demonstrably the
superseding re-run — e.g. its `startedAt` is at or after the cancel's `completedAt`. I
looked for that shape and found none in 30; if it exists, the answer is to order on
`startedAt`, not to restore `>=`.

## P1-B: workflow display name is not unique provenance

**The premise is true and is now established rather than believed.** GitHub's
workflow-syntax reference documents `name:` with no uniqueness constraint, so two files
can both declare `name: CI`. (An *omitted* name falls back to the file path, which is
unique — it is the explicit name that is unconstrained.)

**This PR genuinely widens that exposure, stated plainly:** pre-fix the relief path
collected both a real CANCELLED and a decoy SUCCESS sharing the tuple, so `all(...)` was
False and the cancel blocked. Post-fix the decoy can supersede it. The CI path always had
this; the relief path did not.

**The rollup does not expose workflow-file provenance.** GraphQL has it
(`checkSuite.workflowRun.file.path`, `workflow.databaseId`), but `gh pr view --json
statusCheckRollup` returns exactly `__typename, completedAt, conclusion, detailsUrl,
name, startedAt, status, workflowName`. `detailsUrl` embeds a **run** id — unique per
run, so it cannot separate a decoy from a legitimate re-run of the same file. Pinning on
provenance means replacing this gate's read path and the test seam every test in the file
uses: growth, not a fix round.

**So the precondition is closed instead, and for this hazard that is complete.**
`workflowName` is populated only for Actions check-runs; a non-Actions check-run has none,
so `_ci_identity` returns None and it is never a sibling. Actions check-runs on this
repo's commits come from this repo's own workflow files. New test
`TestWorkflowDisplayNameIsUniqueProvenance` fails CI if two workflow files ever share a
display name, or if a `_MECHANICAL_RESCAN_BY_KIND` pin stops resolving to exactly one
file. This matters because `.github/workflows/` is **not** on the hook surface
(`_HOOK_SURFACE_PREFIXES`), so nothing else would catch it. Repo state today: 5 display
names → 5 files, 0 collisions.

The provenance-pin upgrade remains the right long-term fix and is flagged for a separate
issue.

## Verify-RED: 8 mutations, zero survivors

Added to round 1's six: **M7** relaxes the tie boundary back to `>=` → RED in all three
consumers (primitive, gate, cross-consumer agreement). **M8** creates a *real decoy
workflow file* — the actual hazard, not a mutated test — → RED on both the collision
assertion and the pin assertion, while the guard-the-guard test correctly still passes.
Decoy removal and guard-file restore both hash-verified.

## The #1839 demonstration expired mid-round

**#1839 was pushed at `2026-09-09T22:18:55Z`**, moving its head off `187a809613`. The
success+cancelled pairs live on that commit, and `gh pr view` only reports the *current*
head — so the original live run is no longer reproducible. It is quoted above as it ran.

That same head-scoping also invalidated my first tie measurement: a corpus over 122 PR
*heads* found 1 cancel in 2,138 entries, while this one expired commit carries 16 pairs.
A 16:1 contradiction inside my own data — the instrument was wrong, so the measurement
above uses the runs API, which retains history.

Durable replacement, replayed from the commit via GraphQL (real bytes, both trees loaded
as modules from git blobs, identical sibling modules):

```
commit                 : 187a809613276be99678f6c299b0cee928ff2b94
rollup entries         : 34      distinct identities: 17
success+cancelled pairs: 16
  scanner: CANCELLED 2026-09-09T16:20:59Z  wf=CI
  scanner: SUCCESS   2026-09-09T16:21:59Z  wf=CI

tree                       _pr_ci_status    _mechanical_scan_is_green
origin/main (pre-fix)      green            False
this branch (post-fix)     green            True
```

Pre-fix the two consumers disagree on one payload; post-fix they agree. The tie
tightening did not blind the drop — that pair is 60s apart.

Full guard corpus after round 2: **1,080 passed, 0 failed** across all six guard suites.

E2E (updated — the original head is gone): replay a commit whose rollup carries a
success+cancelled pair for `leak-detector` through `_pr_ci_status` and
`_mechanical_scan_is_green` and confirm both report green, with the cancel dropped only
on a strictly-later success. `187a809613276be99678f6c299b0cee928ff2b94` is a real such
commit and is reachable via GraphQL after its PR's head moves on.
