### PR TITLE
feat(outreach): let a queued message be cancelled before it sends

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,7 @@ Body-scope inventory for cross-tool agents — Genesis's skills and action tools
 - **linkedin-post-writer** — This skill should be used when the user asks to "write a LinkedIn post", "draft a post about", "help me post on LinkedIn", "create LinkedIn content", or when Genesis proactively generates post ideas during surplus compute. Also triggered by content calendar execution or when the user shares a topic they want to write about.
 - **linkedin-profile-optimizer** — This skill should be used when the user asks to "optimize my LinkedIn profile", "update my LinkedIn headline", "rewrite my LinkedIn summary", "improve my LinkedIn about section", or when Genesis identifies that the user's profile doesn't align with their current goals or target audience.
 - **obstacle-resolution** — Resolve obstacles using fallback chains — use when an approach fails, a dependency is unavailable, an API returns errors, or a task is blocked and needs an alternative path forward
-- **onboarding** — First-run onboarding — guides new users through Genesis setup on their first CC session. Configures user profile, essential API keys, Telegram, GitHub backup, and service verification. Triggered automatically when ~/.genesis/setup-complete is absent. Re-runnable by asking Genesis to "run setup" or "reconfigure [section]".
+- **onboarding** — First-run onboarding — guides new users through Genesis setup on their first CC session. Configures user profile, essential API keys, Telegram, GitHub backup, and service verification. Triggered automatically while the install is not yet FUNCTIONAL (the setup floor — Claude Code login + an LLM key + an embedding key — is unmet), not merely while ~/.genesis/setup-complete is absent. Re-runnable by asking Genesis to "run setup" or "reconfigure [section]".
 - **osint** — OSINT investigation — discover, track, and report on people, companies, and technologies
 - **prospect-researcher** — This skill should be used when the user asks to "research this company", "look into this person", "find the best angle for reaching out to", "who should I contact at [company]", "what does [company] care about", or when preparing outreach to a specific target. Also triggered by "help me prepare for an interview with [company]" or "I want to apply to [company]". Combines lead-generation intelligence with LinkedIn-specific approach planning.
 - **research** — Deep research on a topic — use when investigating unfamiliar domains, answering complex questions requiring multiple sources, or when an evaluation flags something for deeper analysis
@@ -189,6 +189,7 @@ Body-scope inventory for cross-tool agents — Genesis's skills and action tools
 - `campaign_trigger` — Manually trigger a campaign tick (bypasses schedule).
 - `campaign_update` — Update campaign configuration.
 - `codebase_navigate` — Navigate the Genesis codebase progressively.
+- `contributor_issue_propose` — Propose a public GitHub issue for the Contributor Work-Log — sanitize it server-side and, if clean, hold it for owner approval on the dashboard.
 - `db_schema` — Query database schema: list all tables, or get columns for a specific table.
 - `direct_session_list` — List recent direct background sessions.
 - `direct_session_run` — Spawn a directed background CC session with profile-based tool restrictions.
@@ -230,8 +231,12 @@ Body-scope inventory for cross-tool agents — Genesis's skills and action tools
 
 **genesis-outreach**
 
+- `marketing_prospects_list` — List the ACTIVE, non-opted-out marketing prospects — the cold-outreach targets the campaign may pitch — so it can enumerate → personalise a pitch → call ``marketing_send(prospect_id, subject, body)``.
+- `marketing_send` — Stage a COLD marketing email to a curated prospect. Returns a neutral queued/refused JSON status.
+- `outreach_cancel` — Cancel a queued, not-yet-sent message by its pending id.
 - `outreach_digest` — Generate a digest of recent outreach activity.
 - `outreach_engagement` — Record an engagement OUTCOME (useful, engaged, acted_on, acknowledged, not_useful, ambivalent, ignored; 'replied' maps to 'useful').
+- `outreach_pending` — List messages QUEUED but not yet sent — the ones `outreach_cancel` can act on.
 - `outreach_poll` — Create a Discord poll via webhook. Returns JSON with message_id.
 - `outreach_preferences` — Get/set user channel preferences and quiet hours.
 - `outreach_queue` — View recent outreach messages.

--- a/changelog.d/20260909213000-added-cancel-a-queued-message.md
+++ b/changelog.d/20260909213000-added-cancel-a-queued-message.md
@@ -1,0 +1,11 @@
+- **A queued message can now be cancelled before it sends.** Scheduling a
+  reminder or notification for later used to be one-way: once queued, the only
+  states the message could reach were "sent" or "sent". Changing your mind meant
+  either letting a stale message arrive and sending a correction after it, or
+  marking the original as delivered — which writes a record saying you were told
+  something you never were, and a later session reads that record and believes
+  it. Cancelling is now its own state, so a retracted message is recorded as
+  retracted rather than disguised as delivered. Two new tools: one lists what is
+  currently queued and when each item is due, the other cancels one by id. A
+  cancel that finds nothing to cancel — an unknown id, a message already sent,
+  or one cancelled a moment ago — says so plainly instead of reporting success.

--- a/changelog.d/20260909220000-fixed-perimeter-sessions-reach-fewer-tools.md
+++ b/changelog.d/20260909220000-fixed-perimeter-sessions-reach-fewer-tools.md
@@ -1,0 +1,14 @@
+- **Sessions that read untrusted incoming messages can no longer reach tools they
+  were never meant to have.** Genesis runs email replies and community messages
+  through deliberately restricted sessions, because the content is written by
+  someone else and may try to give Genesis instructions. Those restrictions were
+  written as a list of what to block, which means anything nobody thought to add
+  to the list was allowed by default — so the restricted sessions could read the
+  queue of pending messages, and could ask for a disk to be grown or a backup to
+  be taken. Both of those last two still needed explicit approval before anything
+  happened, so nothing could have changed the machine on its own; the problem was
+  that they were reachable at all. The community-message session was missing the
+  restrictions entirely, where the email one had them. Both are now covered, and
+  the rule is checked the other way round: every tool on that server must be
+  explicitly either blocked or justified in writing, so a newly added tool fails
+  the check until someone decides which side of the line it belongs on.

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -223,13 +223,6 @@ _NO_OUTREACH_ENGAGEMENT = [
     "mcp__genesis-outreach__outreach_engagement",
     "mcp__genesis-outreach__outreach_preferences",
     "mcp__genesis-outreach__outreach_queue",
-    # outreach_pending lists the QUEUED messages (id + a message preview) and
-    # outreach_cancel retracts one. Denied alongside outreach_queue for the same
-    # reason: a profile that may not read delivered history has no business
-    # reading the pending queue either, and cancel is a destructive write on
-    # owner-facing alerts.
-    "mcp__genesis-outreach__outreach_pending",
-    "mcp__genesis-outreach__outreach_cancel",
 ]
 
 _NO_RECON_WRITES = [
@@ -256,10 +249,26 @@ _NO_OUTREACH_EXTRAS = [
     "mcp__genesis-outreach__outreach_send_and_wait",
     "mcp__genesis-outreach__outreach_poll",
     "mcp__genesis-outreach__outreach_digest",
-    # Queue introspection is an exfiltration surface — outreach_pending returns
-    # up to 50 queued messages with a preview of each, which an injected inbound
-    # message could have echoed back through the profile's own reply tool. Cancel
-    # is worse: it silently retracts the owner's queued reminders and alerts.
+]
+
+# The pending-queue controls: read what the owner has scheduled, or retract it.
+#
+# Denied on EVERY background profile, which is broader than the perimeter groups
+# above and deliberately so. PROFILES governs background sessions only — the
+# owner's own interactive session does not go through it — and no background
+# session has business reading or cancelling the owner's queued messages. So the
+# allowed set here is EMPTY, which makes the rule trivial to state and to test,
+# and costs nothing: both tools are new in this change, so nothing depends on
+# them.
+#
+# Scoped this way after review found `steward` still reachable: it ingests
+# external GitHub PR content and can publish `gh` comments, so an injected PR
+# body could read queued-message previews out through a comment or silently
+# cancel the owner's alerts. `interact` (arbitrary browser page content) and
+# `campaign` (external platform replies) carry the same shape. Enumerating the
+# perimeter profile-by-profile is what let steward slip; denying everywhere and
+# testing for it removes the judgement call entirely.
+_NO_OUTREACH_QUEUE_CONTROL = [
     "mcp__genesis-outreach__outreach_pending",
     "mcp__genesis-outreach__outreach_cancel",
 ]
@@ -315,16 +324,19 @@ PROFILES: dict[str, list[str]] = {
         + _NO_OUTREACH_ENGAGEMENT
         + _NO_RECON_WRITES
         + _NO_MARKETING_SEND
+        + _NO_OUTREACH_QUEUE_CONTROL
     ),
     "interact": (
         _UNIVERSAL_DISALLOW + _NO_OUTREACH_ENGAGEMENT + _NO_RECON_WRITES + _NO_MARKETING_SEND
+        + _NO_OUTREACH_QUEUE_CONTROL
     ),
     "research": (
         _UNIVERSAL_DISALLOW + _NO_OUTREACH_SEND + _NO_BROWSER_INTERACTION + _NO_MARKETING_SEND
+        + _NO_OUTREACH_QUEUE_CONTROL
     ),
     # `campaign` is the ONLY profile that may call marketing_send — the intended
     # autonomous cold-marketing caller. Every other profile denies it above/below.
-    "campaign": (_UNIVERSAL_DISALLOW + _NO_BROWSER_INTERACTION),
+    "campaign": (_UNIVERSAL_DISALLOW + _NO_BROWSER_INTERACTION + _NO_OUTREACH_QUEUE_CONTROL),
     # ── Steward profile ──────────────────────────────────────────
     # For the upstream-PR stewardship campaign. UNIQUE among profiles: it
     # grants Bash (so it can run `gh`) — every other profile blocks Bash.
@@ -337,6 +349,7 @@ PROFILES: dict[str, list[str]] = {
         + _NO_BROWSER_INTERACTION
         + _NO_FILE_WRITE
         + _NO_MARKETING_SEND
+        + _NO_OUTREACH_QUEUE_CONTROL
     ),
     # ── Community responder profile ─────────────────────────────
     # Reactive community responder: reads a community's channels and replies
@@ -361,6 +374,7 @@ PROFILES: dict[str, list[str]] = {
         + _NO_OUTREACH_EXTRAS
         + _NO_PROVISIONING
         + _NO_MARKETING_SEND
+        + _NO_OUTREACH_QUEUE_CONTROL
     ),
     # ── Perimeter profile ────────────────────────────────────────
     # For sessions that process untrusted inbound content (email
@@ -380,6 +394,7 @@ PROFILES: dict[str, list[str]] = {
         + _NO_OUTREACH_EXTRAS
         + _NO_PROVISIONING
         + _NO_MARKETING_SEND
+        + _NO_OUTREACH_QUEUE_CONTROL
     ),
 }
 

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -223,6 +223,13 @@ _NO_OUTREACH_ENGAGEMENT = [
     "mcp__genesis-outreach__outreach_engagement",
     "mcp__genesis-outreach__outreach_preferences",
     "mcp__genesis-outreach__outreach_queue",
+    # outreach_pending lists the QUEUED messages (id + a message preview) and
+    # outreach_cancel retracts one. Denied alongside outreach_queue for the same
+    # reason: a profile that may not read delivered history has no business
+    # reading the pending queue either, and cancel is a destructive write on
+    # owner-facing alerts.
+    "mcp__genesis-outreach__outreach_pending",
+    "mcp__genesis-outreach__outreach_cancel",
 ]
 
 _NO_RECON_WRITES = [
@@ -238,10 +245,41 @@ _NO_WEB_TOOLS = [
 ]
 
 # Perimeter sessions: block outreach tools beyond basic send.
+#
+# NOTE ON POLARITY — this is a DENY list, so a tool nobody enumerates is
+# ALLOWED. The `mail` profile's comment claims "only outreach_send is
+# available"; that is a description of the intended result, not something the
+# mechanism enforces. Every new genesis-outreach tool is reachable from the
+# untrusted-inbound perimeter until it is named here. Add new tools to this list
+# as part of adding them, not afterwards.
 _NO_OUTREACH_EXTRAS = [
     "mcp__genesis-outreach__outreach_send_and_wait",
     "mcp__genesis-outreach__outreach_poll",
     "mcp__genesis-outreach__outreach_digest",
+    # Queue introspection is an exfiltration surface — outreach_pending returns
+    # up to 50 queued messages with a preview of each, which an injected inbound
+    # message could have echoed back through the profile's own reply tool. Cancel
+    # is worse: it silently retracts the owner's queued reminders and alerts.
+    "mcp__genesis-outreach__outreach_pending",
+    "mcp__genesis-outreach__outreach_cancel",
+]
+
+# Host-capacity actuators. They live on the genesis-outreach server (it owns the
+# owner-approval channel they use), so a profile that mounts that server for its
+# reply tool gets these too unless they are named here — which is how they were
+# reachable from the untrusted-inbound perimeter until the allowlist-polarity test
+# in tests/test_cc/test_direct_session_profiles.py surfaced them.
+#
+# Both are approval-gated (an APPROVE/DENY request goes to the owner's channel and
+# nothing mutates without it), so this is not a silent-compromise path. It is still
+# wrong: injected inbound content should not be able to raise plausible-looking
+# infrastructure approval prompts in the owner's channel, and the gate is defence
+# in depth rather than a reason to leave the actuator reachable. Denied on the
+# perimeter only — an autonomous working session asking the owner to grow a disk is
+# the intended use.
+_NO_PROVISIONING = [
+    "mcp__genesis-outreach__provision_grow",
+    "mcp__genesis-outreach__provision_vzdump",
 ]
 
 # Cold-marketing tools. marketing_send resolves its recipient in-code from the
@@ -305,11 +343,23 @@ PROFILES: dict[str, list[str]] = {
     # via the discord-bot MCP server. MCP config loads discord-bot + health +
     # outreach (no memory server). Belt-and-suspenders: block memory writes at
     # tool level too, in case MCP config generation fails and falls back to full.
+    # Also a perimeter profile — it reads external Discord messages (see
+    # _PROFILE_ORIGIN below, which classifies it as external-ingesting). It mounts
+    # genesis-outreach (session_config.py) but carried NEITHER outreach deny group,
+    # so the whole outreach surface beyond send — digest, queue, poll,
+    # send_and_wait, engagement, preferences — plus both host-capacity actuators
+    # were reachable from attacker-controlled Discord content. `mail` had the same
+    # shape and was covered; this profile was simply never given the same groups.
+    # Surfaced by the allowlist-polarity test, which is the point of stating the
+    # boundary as an allowlist: an `in`-based test cannot fail for an omission.
     "community-responder": (
         _UNIVERSAL_DISALLOW
         + _NO_BROWSER_INTERACTION
         + _NO_MEMORY_WRITES
         + _NO_FOLLOW_UPS
+        + _NO_OUTREACH_ENGAGEMENT
+        + _NO_OUTREACH_EXTRAS
+        + _NO_PROVISIONING
         + _NO_MARKETING_SEND
     ),
     # ── Perimeter profile ────────────────────────────────────────
@@ -328,6 +378,7 @@ PROFILES: dict[str, list[str]] = {
         + _NO_RECON_WRITES
         + _NO_WEB_TOOLS
         + _NO_OUTREACH_EXTRAS
+        + _NO_PROVISIONING
         + _NO_MARKETING_SEND
     ),
 }

--- a/src/genesis/db/crud/pending_outreach.py
+++ b/src/genesis/db/crud/pending_outreach.py
@@ -5,9 +5,12 @@ Foreground CC sessions write here; the bridge drains it via the outreach pipelin
 
 from __future__ import annotations
 
+import logging
 import uuid
 
 import aiosqlite
+
+logger = logging.getLogger(__name__)
 
 
 async def enqueue(
@@ -77,12 +80,73 @@ async def drain(
     cursor = await db.execute(
         """SELECT rowid AS rowid, * FROM pending_outreach
            WHERE delivered = 0
+             AND cancelled_at IS NULL
              AND (deliver_after IS NULL OR deliver_after <= ?)
            ORDER BY created_at ASC
            LIMIT 20""",
         (now,),
     )
     return [dict(r) for r in await cursor.fetchall()]
+
+
+async def cancel(db: aiosqlite.Connection, pending_id: str) -> tuple[bool, str]:
+    """Cancel a still-queued message. Returns (cancelled, reason).
+
+    Exists so that changing a queued message (a reminder whose time moved, a
+    notification made obsolete by events) does not require either sending a
+    duplicate or calling :func:`mark_delivered` on the original. That second
+    option is the one worth naming: it writes ``delivered = 1`` for a message
+    that was never sent, into a table ``outreach_queue`` reads back, so a later
+    session sees it as delivered and concludes the recipient was told something
+    they were not. Cancellation is a distinct state precisely so it cannot be
+    mistaken for delivery.
+
+    Never raises. The narrow WHERE clause is what makes the first element mean
+    "I cancelled it" rather than "the row exists": a caller can act on True.
+
+    The reason distinguishes the three ways a cancel can find nothing to cancel,
+    and one of them must NOT be described as delivery. ``delivered = 1`` in this
+    table means DEQUEUED, not sent: the drain writes it for ``HELD`` (handed to
+    the autonomy gate's approval queue, and the message still sends once the
+    owner approves), for ``IGNORED``, and for the 24h age-out whose own log line
+    says "never delivered" — see ``outreach/scheduler.py`` around the terminal-
+    disposition branch. So "already delivered, cannot be un-sent" would be a
+    false statement in exactly the window where retraction matters most: a gated
+    message waiting on approval. ``already_dequeued`` is the honest name.
+
+    Making ``delivered`` stop meaning two things is a larger fix in the scheduler
+    and is tracked separately; this function refuses to assert what it cannot
+    know.
+    """
+    from datetime import UTC, datetime
+
+    cursor = await db.execute(
+        """UPDATE pending_outreach
+              SET cancelled_at = ?
+            WHERE id = ?
+              AND delivered = 0
+              AND cancelled_at IS NULL""",
+        (datetime.now(UTC).isoformat(), pending_id),
+    )
+    await db.commit()
+    if cursor.rowcount > 0:
+        return True, "cancelled"
+
+    # Positional, not by name: this module's other readers happen to run on a
+    # Row-factory connection, but cancel() must not depend on one being set.
+    row_cursor = await db.execute(
+        "SELECT cancelled_at FROM pending_outreach WHERE id = ?",
+        (pending_id,),
+    )
+    row = await row_cursor.fetchone()
+    if row is None:
+        return False, "unknown_id"
+    # Ordering matters: a row can be BOTH cancelled and later dequeued if a cancel
+    # lost a race with the send loop. Reporting already_cancelled there is the
+    # accurate answer to "did my cancel take effect" — it did, on the row.
+    if row[0] is not None:
+        return False, "already_cancelled"
+    return False, "already_dequeued"
 
 
 async def mark_delivered(
@@ -138,19 +202,39 @@ async def ensure_table(db: aiosqlite.Connection) -> None:
             delivered_at        TEXT,
             thread_id           TEXT,
             validated_recipient TEXT,
-            labeled_surplus     INTEGER NOT NULL DEFAULT 0
+            labeled_surplus     INTEGER NOT NULL DEFAULT 0,
+            cancelled_at        TEXT
         )
     """)
     # Legacy DBs whose pending_outreach predates labeled_surplus: add it here too
     # (this standalone-fallback path runs before the numbered migration on a
     # subprocess-only boot). Guarded so a re-run / fresh DB never errors.
+    # One try PER column. They used to share a single `suppress(Exception)`, so a
+    # transient failure on the first ALTER (SQLITE_LOCKED on DDL is real enough
+    # that the migration runner carries a retry loop for it) silently skipped the
+    # second — and `cancelled_at` missing is not a degraded flag, it breaks
+    # `drain`'s WHERE clause and stops the whole queue delivering.
     import contextlib
 
+    cols: set[str] = set()
     with contextlib.suppress(Exception):
         cursor = await db.execute("PRAGMA table_info(pending_outreach)")
         cols = {row[1] for row in await cursor.fetchall()}
-        if "labeled_surplus" not in cols:
-            await db.execute(
-                "ALTER TABLE pending_outreach ADD COLUMN labeled_surplus INTEGER NOT NULL DEFAULT 0"
-            )
+
+    for column, ddl in (
+        (
+            "labeled_surplus",
+            "ALTER TABLE pending_outreach ADD COLUMN labeled_surplus INTEGER NOT NULL DEFAULT 0",
+        ),
+        ("cancelled_at", "ALTER TABLE pending_outreach ADD COLUMN cancelled_at TEXT"),
+    ):
+        if column in cols:
+            continue
+        try:
+            await db.execute(ddl)
+        except Exception as exc:  # noqa: BLE001 — one column must not block the next
+            # A duplicate column is the expected no-op when the PRAGMA read above
+            # failed; anything else is real and must not vanish.
+            if "duplicate column" not in str(exc).lower():
+                logger.warning("pending_outreach: ALTER adding %s failed: %s", column, exc)
     await db.commit()

--- a/src/genesis/db/migrations/20260909195559_pending_outreach_cancelled_at.py
+++ b/src/genesis/db/migrations/20260909195559_pending_outreach_cancelled_at.py
@@ -1,0 +1,37 @@
+"""Add ``cancelled_at`` to ``pending_outreach`` so a queued message can be CANCELLED.
+
+The table could previously only express enqueued or DELIVERED. With no third
+state, changing a queued reminder's delivery time left two bad options: send a
+duplicate, or call ``mark_delivered`` on the original — which writes
+``delivered = 1`` for a message that was never sent, into a store that
+``outreach_queue`` reads back. A later session would then see the message as
+delivered and conclude the recipient had been told something they had not.
+
+ONE nullable timestamp rather than a ``cancelled`` flag plus a ``cancelled_at``,
+deliberately diverging from the ``delivered`` / ``delivered_at`` pair above it:
+NULL means live and non-NULL means cancelled-at-that-time, so there is no way to
+represent the inconsistent "cancelled but no timestamp" state that a separate
+boolean allows. Noted here because the divergence is a choice, not an oversight.
+
+Additive, nullable, no backfill — existing rows are by definition not cancelled,
+which is exactly what NULL means. Idempotent via ``PRAGMA table_info``.
+Self-contained per migration convention — no genesis imports.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='pending_outreach'"
+    )
+    if not await cursor.fetchone():
+        return  # bare DB (runner unit tests) — nothing to alter
+
+    col_cursor = await db.execute("PRAGMA table_info(pending_outreach)")
+    cols = {row[1] for row in await col_cursor.fetchall()}
+
+    if "cancelled_at" not in cols:
+        await db.execute("ALTER TABLE pending_outreach ADD COLUMN cancelled_at TEXT")

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -286,7 +286,11 @@ TABLES = {
             delivered_at        TEXT,
             thread_id           TEXT,
             validated_recipient TEXT,
-            labeled_surplus     INTEGER NOT NULL DEFAULT 0
+            labeled_surplus     INTEGER NOT NULL DEFAULT 0,
+            -- NULL = live; non-NULL = cancelled at that time. Deliberately ONE
+            -- column rather than a flag + timestamp like `delivered` above: this
+            -- way "cancelled with no timestamp" is unrepresentable.
+            cancelled_at        TEXT
         )
     """,
     "brainstorm_log": """

--- a/src/genesis/mcp/outreach_mcp.py
+++ b/src/genesis/mcp/outreach_mcp.py
@@ -500,6 +500,86 @@ async def outreach_queue(
         return [{"error": f"Query failed: {exc}"}]
 
 
+@mcp.tool()
+async def outreach_pending() -> list[dict]:
+    """List messages QUEUED but not yet sent — the ones `outreach_cancel` can act on.
+
+    Deliberately a separate tool from ``outreach_queue``, which reads
+    ``outreach_history`` (messages already DELIVERED) and therefore never shows a
+    scheduled message at all. That gap is why this exists: without it, a queued
+    message is only addressable by the id its ``outreach_send`` call returned, so
+    once that id is out of view the message cannot be found, inspected, or
+    cancelled — it simply arrives.
+
+    Returns each row's id, when it is due (``deliver_after``), and a short message
+    preview, soonest-due first. A NULL ``deliver_after`` means "goes out on the
+    next drain tick", so it sorts FIRST — ordering on ``deliver_after`` directly
+    would push the imminent messages behind everything scheduled for next month,
+    and the LIMIT would then drop exactly the ones worth cancelling.
+    """
+    if not _db:
+        return [{"error": "not initialized"}]
+    try:
+        from genesis.db.crud import pending_outreach
+
+        await pending_outreach.ensure_table(_db)  # idempotent; init is fire-and-forget
+        cursor = await _db.execute(
+            """SELECT id, category, channel, urgency, deliver_after, created_at,
+                      substr(message, 1, 160) AS message_preview
+                 FROM pending_outreach
+                WHERE delivered = 0
+                  AND cancelled_at IS NULL
+                ORDER BY COALESCE(deliver_after, created_at) ASC, created_at ASC
+                LIMIT 50"""
+        )
+        columns = [d[0] for d in cursor.description]
+        return [dict(zip(columns, row, strict=False)) for row in await cursor.fetchall()]
+    except Exception as exc:
+        return [{"error": f"Query failed: {exc}"}]
+
+
+@mcp.tool()
+async def outreach_cancel(pending_id: str) -> str:
+    """Cancel a queued, not-yet-sent message by its pending id.
+
+    Use this to retract or reschedule a queued message: cancel, then re-send with
+    the new timing. Before this existed the only options were to send a duplicate
+    or to mark the original DELIVERED — and that second one writes a false record
+    into a table that gets read back, so a later session concludes the recipient
+    was told something they were not.
+
+    Returns a status naming what actually happened, because "cancelled" and "there
+    was nothing to cancel" must not look alike:
+      cancelled         — this call cancelled a live queued message
+      already_cancelled — a previous cancel already took effect
+      already_dequeued  — the message has left the queue. It was sent, OR it is
+                          HELD at the autonomy gate awaiting the owner's approval
+                          (in which case it has NOT been sent and still will be),
+                          OR it aged out after 24h. The queue writes the same flag
+                          for all three, so this tool does not claim delivery it
+                          cannot verify.
+      unknown_id        — no such pending message
+
+    Get ids from ``outreach_pending``.
+    """
+    if not _db:
+        return json.dumps({"error": "not initialized"})
+    try:
+        from genesis.db.crud import pending_outreach
+
+        await pending_outreach.ensure_table(_db)  # idempotent; init is fire-and-forget
+        did, reason = await pending_outreach.cancel(_db, pending_id)
+    except Exception as exc:
+        return json.dumps({"error": f"Cancel failed: {exc}"})
+    payload = {"status": reason, "cancelled": did, "pending_id": pending_id}
+    if reason == "already_dequeued":
+        payload["note"] = (
+            "left the queue — sent, awaiting approval at the autonomy gate, or aged "
+            "out. Not necessarily delivered."
+        )
+    return json.dumps(payload)
+
+
 async def _server_rpc(path: str, payload: dict, *, read_timeout_s: float) -> dict:
     """Bridge a synchronous outreach op to genesis-server, which owns the live
     pipeline this subprocess lacks. POSTs to the in-process dashboard route and

--- a/src/genesis/mcp/outreach_mcp.py
+++ b/src/genesis/mcp/outreach_mcp.py
@@ -501,7 +501,7 @@ async def outreach_queue(
 
 
 @mcp.tool()
-async def outreach_pending() -> list[dict]:
+async def outreach_pending(limit: int = 50, offset: int = 0) -> dict:
     """List messages QUEUED but not yet sent — the ones `outreach_cancel` can act on.
 
     Deliberately a separate tool from ``outreach_queue``, which reads
@@ -516,26 +516,51 @@ async def outreach_pending() -> list[dict]:
     next drain tick", so it sorts FIRST — ordering on ``deliver_after`` directly
     would push the imminent messages behind everything scheduled for next month,
     and the LIMIT would then drop exactly the ones worth cancelling.
+
+    PAGED, with a denominator. Returns
+    ``{items, total, offset, limit, truncated}`` — never a bare list. A bare list
+    capped at 50 is indistinguishable from a complete one, so a caller with 60
+    queued messages would have concluded it had seen them all and that the missing
+    ten did not exist; and since every id worth cancelling comes from this tool,
+    the invisible ones were also the uncancellable ones. ``total`` is the real
+    count and ``truncated`` says outright whether more remain; page with ``offset``.
     """
     if not _db:
-        return [{"error": "not initialized"}]
+        return {"error": "not initialized"}
+    try:
+        limit = max(1, min(int(limit), 200))
+        offset = max(0, int(offset))
+    except (TypeError, ValueError):
+        return {"error": "limit and offset must be integers"}
     try:
         from genesis.db.crud import pending_outreach
 
         await pending_outreach.ensure_table(_db)  # idempotent; init is fire-and-forget
+        where = "WHERE delivered = 0 AND cancelled_at IS NULL"
+        count_cursor = await _db.execute(
+            f"SELECT COUNT(*) FROM pending_outreach {where}"  # noqa: S608 — literal
+        )
+        total = int((await count_cursor.fetchone())[0])
         cursor = await _db.execute(
-            """SELECT id, category, channel, urgency, deliver_after, created_at,
+            f"""SELECT id, category, channel, urgency, deliver_after, created_at,
                       substr(message, 1, 160) AS message_preview
                  FROM pending_outreach
-                WHERE delivered = 0
-                  AND cancelled_at IS NULL
+                {where}
                 ORDER BY COALESCE(deliver_after, created_at) ASC, created_at ASC
-                LIMIT 50"""
+                LIMIT ? OFFSET ?""",  # noqa: S608 — `where` is a literal above
+            (limit, offset),
         )
         columns = [d[0] for d in cursor.description]
-        return [dict(zip(columns, row, strict=False)) for row in await cursor.fetchall()]
+        items = [dict(zip(columns, row, strict=False)) for row in await cursor.fetchall()]
+        return {
+            "items": items,
+            "total": total,
+            "offset": offset,
+            "limit": limit,
+            "truncated": offset + len(items) < total,
+        }
     except Exception as exc:
-        return [{"error": f"Query failed: {exc}"}]
+        return {"error": f"Query failed: {exc}"}
 
 
 @mcp.tool()
@@ -560,7 +585,7 @@ async def outreach_cancel(pending_id: str) -> str:
                           cannot verify.
       unknown_id        — no such pending message
 
-    Get ids from ``outreach_pending``.
+    Get ids from ``outreach_pending`` (paged: check its ``truncated`` flag).
     """
     if not _db:
         return json.dumps({"error": "not initialized"})

--- a/src/genesis/outreach/scheduler.py
+++ b/src/genesis/outreach/scheduler.py
@@ -705,6 +705,29 @@ class OutreachScheduler:
                             )
                             continue
 
+                    # Re-read the cancel state immediately before committing to a
+                    # send. `drain` took a snapshot up to 20 rows ago, and each
+                    # row ahead of this one can cost an LLM draft plus an adapter
+                    # round-trip — so the snapshot is stale by seconds to minutes,
+                    # and that is precisely the window in which someone cancels
+                    # (they cancel because the message is about to go out). Without
+                    # this, `pending_outreach.cancel` returns "cancelled" and the
+                    # message ships anyway, leaving a row recorded as both
+                    # cancelled and delivered. A narrow race remains between this
+                    # read and the send itself; that one is inherent without row
+                    # locking, and it is microseconds rather than minutes.
+                    _cancel_cursor = await self._db.execute(
+                        "SELECT cancelled_at FROM pending_outreach WHERE rowid = ?",
+                        (row["rowid"],),
+                    )
+                    _cancel_row = await _cancel_cursor.fetchone()
+                    if _cancel_row is not None and _cancel_row[0] is not None:
+                        logger.info(
+                            "Pending outreach %s cancelled after drain — not sending",
+                            row.get("id") or f"rowid:{row.get('rowid')}",
+                        )
+                        continue
+
                     # Validate category — map known non-enum values, fall
                     # back to DIGEST (not ALERT) for truly unknown ones.
                     _CATEGORY_ALIASES = {

--- a/tests/test_cc/test_direct_session_profiles.py
+++ b/tests/test_cc/test_direct_session_profiles.py
@@ -959,3 +959,44 @@ def test_interact_allows_follow_up_update():
 
 def test_research_maps_to_research_mcp_profile():
     assert _PROFILE_TO_MCP["research"] == "research"
+
+
+# --- perimeter outreach surface: ALLOWLIST polarity ---
+# PROFILES entries are DENY lists, so a tool nobody enumerates is ALLOWED. Every
+# test above is `in` / `not in` on a named tool, which by construction cannot fail
+# for a tool that was just added — the `mail` profile's own comment claims "only
+# outreach_send is available", but nothing enforced that claim.
+#
+# This test states it as an allowlist instead: enumerate what the genesis-outreach
+# server actually registers, and require the perimeter profile to deny everything
+# outside a small, explicitly-reasoned allowed set. A new outreach tool now fails
+# this test until someone decides which side of the boundary it belongs on.
+#
+# It caught a real regression on the change that added it: outreach_pending (up to
+# 50 queued messages with previews — an exfiltration surface for injected inbound
+# content) and outreach_cancel (silently retracts the owner's queued alerts) were
+# both reachable from `mail`.
+
+# Deliberately allowed on the untrusted-inbound perimeter, with the reason:
+#   outreach_send  — the profile exists to reply to email; this IS its actuator.
+_PERIMETER_ALLOWED_OUTREACH = {"outreach_send"}
+
+
+async def test_perimeter_profiles_deny_every_outreach_tool_but_the_reply_actuator():
+    from genesis.mcp.outreach_mcp import mcp as outreach_mcp
+
+    registered = set(await outreach_mcp.get_tools())
+    assert "outreach_send" in registered, "enumeration is stale — the server changed"
+
+    for profile in ("mail", "community-responder"):
+        denied = set(PROFILES[profile])
+        should_deny = registered - _PERIMETER_ALLOWED_OUTREACH
+        missing = sorted(
+            name for name in should_deny if f"mcp__genesis-outreach__{name}" not in denied
+        )
+        assert not missing, (
+            f"profile {profile!r} does not deny outreach tool(s) {missing}. PROFILES is a "
+            "DENY list, so an unlisted tool is ALLOWED to a session reading "
+            "attacker-controlled inbound content. Add each to a _NO_OUTREACH_* group, "
+            "or to _PERIMETER_ALLOWED_OUTREACH with a written reason."
+        )

--- a/tests/test_cc/test_direct_session_profiles.py
+++ b/tests/test_cc/test_direct_session_profiles.py
@@ -1000,3 +1000,34 @@ async def test_perimeter_profiles_deny_every_outreach_tool_but_the_reply_actuato
             "attacker-controlled inbound content. Add each to a _NO_OUTREACH_* group, "
             "or to _PERIMETER_ALLOWED_OUTREACH with a written reason."
         )
+
+
+def test_no_background_profile_can_read_or_cancel_the_pending_queue():
+    """EVERY background profile must deny the queue controls — allowed set is empty.
+
+    PROFILES governs background sessions only; the owner's own interactive session
+    does not go through it. No background session has business reading what the
+    owner has scheduled or retracting it, so this is stated over ALL profiles
+    rather than over a hand-maintained perimeter list.
+
+    That distinction is the finding: enumerating the perimeter profile-by-profile
+    left `steward` reachable, and steward ingests external GitHub PR content and
+    can publish `gh` comments — so an injected PR body could read queued-message
+    previews out through a comment, or silently cancel the owner's alerts.
+    `interact` (arbitrary browser pages) and `campaign` (external platform
+    replies) have the same shape. Iterating PROFILES removes the judgement call,
+    and a NEW profile is covered the moment it is added.
+    """
+    queue_controls = {
+        "mcp__genesis-outreach__outreach_pending",
+        "mcp__genesis-outreach__outreach_cancel",
+    }
+    gaps = {
+        profile: sorted(queue_controls - set(denied))
+        for profile, denied in PROFILES.items()
+        if queue_controls - set(denied)
+    }
+    assert not gaps, (
+        "background profile(s) can reach the pending-queue controls: "
+        f"{gaps}. Add _NO_OUTREACH_QUEUE_CONTROL to each."
+    )

--- a/tests/test_db/test_migration_pending_outreach_cancelled_at.py
+++ b/tests/test_db/test_migration_pending_outreach_cancelled_at.py
@@ -1,0 +1,102 @@
+"""Migration 20260909195559 — ``cancelled_at`` onto ``pending_outreach``.
+
+Two properties of ``up()``, mirroring the 0089 pattern for the same table:
+
+1. Idempotency comes from the ``PRAGMA table_info`` guard, not from suppressing
+   an error — a re-run is a clean no-op rather than a caught "duplicate column
+   name". So a genuine ALTER failure on an existing table still propagates.
+2. The ALTER is guarded on ``pending_outreach`` EXISTING, because that table is
+   created by ``create_all_tables`` and by ``ensure_table``, never by a
+   migration. Exercised in isolation (the migration-runner harness, which has no
+   ``create_all_tables``) the table is legitimately absent and ``up()`` skips —
+   and must NOT fabricate a stub table, or the real CREATE later finds one
+   already there and silently keeps the wrong shape.
+
+This is the path a real upgrade of an existing install takes. ``ensure_table``'s
+ALTER covers the subprocess-only boot; this covers the server boot. Both were
+written, only one was tested, and mutation verification is what said so.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+_MIG = importlib.import_module("genesis.db.migrations.20260909195559_pending_outreach_cancelled_at")
+
+# The pre-migration shape, trimmed to what the ALTER needs to find.
+_LEGACY = """
+    CREATE TABLE pending_outreach (
+        id           TEXT PRIMARY KEY,
+        message      TEXT NOT NULL,
+        category     TEXT NOT NULL,
+        created_at   TEXT NOT NULL,
+        delivered    INTEGER NOT NULL DEFAULT 0,
+        delivered_at TEXT
+    )
+"""
+
+
+async def _columns(conn, table):
+    cur = await conn.execute(f"PRAGMA table_info({table})")
+    return [r[1] for r in await cur.fetchall()]
+
+
+@pytest.mark.asyncio
+async def test_up_adds_cancelled_at_idempotently(tmp_path):
+    conn = await aiosqlite.connect(str(tmp_path / "t.db"))
+    try:
+        await conn.execute(_LEGACY)
+        await conn.commit()
+        assert "cancelled_at" not in await _columns(conn, "pending_outreach")
+
+        await _MIG.up(conn)
+        await conn.commit()
+        cols = await _columns(conn, "pending_outreach")
+        assert "cancelled_at" in cols
+
+        # Re-run: no-op, and specifically not a second column.
+        await _MIG.up(conn)
+        await conn.commit()
+        assert await _columns(conn, "pending_outreach") == cols
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_up_preserves_existing_rows_as_live(tmp_path):
+    """Additive with no backfill: a row that existed before the migration is by
+    definition not cancelled, and NULL is exactly what that means. A non-NULL
+    default would retroactively mark every queued message cancelled."""
+    conn = await aiosqlite.connect(str(tmp_path / "t.db"))
+    try:
+        await conn.execute(_LEGACY)
+        await conn.execute(
+            "INSERT INTO pending_outreach (id, message, category, created_at) "
+            "VALUES ('keep', 'queued before the migration', 'notification', '2026-01-01')"
+        )
+        await conn.commit()
+
+        await _MIG.up(conn)
+        await conn.commit()
+
+        cur = await conn.execute("SELECT cancelled_at FROM pending_outreach WHERE id = 'keep'")
+        assert (await cur.fetchone())[0] is None
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_up_skips_and_fabricates_nothing_when_the_table_is_absent(tmp_path):
+    """The runner-in-isolation shape. Must not raise, and must not create a stub —
+    a fabricated table would shadow the real CREATE and keep the wrong schema."""
+    conn = await aiosqlite.connect(str(tmp_path / "bare.db"))
+    try:
+        await _MIG.up(conn)  # must not raise "no such table"
+        await conn.commit()
+        cur = await conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        assert "pending_outreach" not in {r[0] for r in await cur.fetchall()}
+    finally:
+        await conn.close()

--- a/tests/test_db/test_pending_outreach.py
+++ b/tests/test_db/test_pending_outreach.py
@@ -100,3 +100,146 @@ async def test_mark_delivered_by_rowid_clears_null_id_row(db):
         is True
     )
     assert await pending_outreach.drain(db, now="2999-01-01T00:00:00+00:00") == []
+
+
+# ── cancel ────────────────────────────────────────────────────────────────────
+# A queued message could previously only be enqueued or marked DELIVERED. With no
+# cancel, changing a reminder's time meant either sending a duplicate or writing
+# delivered=1 for something never sent — a false record in a store that gets read
+# back. Cancelling records a distinct state instead.
+
+
+@pytest.mark.asyncio
+async def test_cancel_removes_a_queued_message_from_the_drain(db):
+    """The load-bearing assertion: a cancelled row must not be DELIVERED.
+
+    `drain` was the only pending-predicate over this table, so it is the one gate
+    that has to learn about the new state — miss it and cancel silently does
+    nothing while reporting success.
+    """
+    pid = await pending_outreach.enqueue(
+        db,
+        message="reminder at the wrong time",
+        category="notification",
+    )
+    assert await pending_outreach.drain(db, now="2999-01-01T00:00:00+00:00")
+
+    assert await pending_outreach.cancel(db, pid) == (True, "cancelled")
+    assert await pending_outreach.drain(db, now="2999-01-01T00:00:00+00:00") == []
+
+
+@pytest.mark.asyncio
+async def test_cancel_is_distinguishable_from_delivered(db):
+    """Cancelled must NOT masquerade as delivered — that was the whole point."""
+    pid = await pending_outreach.enqueue(
+        db,
+        message="m",
+        category="notification",
+    )
+    await pending_outreach.cancel(db, pid)
+    cur = await db.execute(
+        "SELECT delivered, delivered_at, cancelled_at FROM pending_outreach WHERE id = ?",
+        (pid,),
+    )
+    row = await cur.fetchone()
+    assert row["delivered"] == 0, "a cancelled message must not read as delivered"
+    assert row["delivered_at"] is None
+    assert row["cancelled_at"] is not None, "cancellation must be recorded, not inferred"
+
+
+@pytest.mark.asyncio
+async def test_cancel_refuses_a_dequeued_message_without_claiming_delivery(db):
+    """Cancelling a message that has left the queue must fail — and the reason must
+    NOT say "delivered", because the flag does not mean that.
+
+    ``delivered = 1`` is written by the drain for three outcomes, only one of which
+    is a send: DELIVERED/ENGAGED (sent), HELD (handed to the autonomy gate, still
+    awaiting the owner's approval, and it WILL send afterwards), and the 24h
+    age-out whose own log line reads "never delivered". An earlier version of this
+    reason said "already delivered (cannot be un-sent)" — false in the HELD case,
+    which is precisely the window where someone wants to retract.
+    """
+    pid = await pending_outreach.enqueue(db, message="m", category="notification")
+    await pending_outreach.mark_delivered(db, pid, delivered_at="2026-01-01T00:00:00+00:00")
+    assert await pending_outreach.cancel(db, pid) == (False, "already_dequeued"), (
+        "delivered=1 also means HELD / aged-out, so the reason must not assert delivery"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancel_unknown_id_returns_false(db):
+    """An unknown id is not a silent success — the caller must be able to tell."""
+    assert await pending_outreach.cancel(db, "no-such-id") == (False, "unknown_id")
+
+
+@pytest.mark.asyncio
+async def test_cancel_is_idempotent_but_reports_honestly(db):
+    """A second cancel changes nothing and says so, rather than claiming a fresh
+    cancellation (which would let a caller double-count)."""
+    pid = await pending_outreach.enqueue(db, message="m", category="notification")
+    assert await pending_outreach.cancel(db, pid) == (True, "cancelled")
+    assert await pending_outreach.cancel(db, pid) == (False, "already_cancelled")
+
+
+@pytest.mark.asyncio
+async def test_ensure_table_includes_cancelled_at(db):
+    """The CREATE path carries the column — ensure_table is the standalone
+    fallback used on a subprocess-only boot, before the numbered migration runs."""
+    cur = await db.execute("PRAGMA table_info(pending_outreach)")
+    cols = {row[1] for row in await cur.fetchall()}
+    assert "cancelled_at" in cols
+
+
+@pytest.mark.asyncio
+async def test_ensure_table_adds_cancelled_at_to_a_legacy_table(tmp_path):
+    """The ALTER path — the one every EXISTING install takes, and the one the
+    CREATE-path test above cannot reach.
+
+    Mutation-verified: deleting the ALTER left the CREATE-path test green, because
+    a fresh table is built with the column already in it. So the branch that runs
+    on a real upgrade had no coverage at all. Build the pre-column shape
+    explicitly, or this test silently becomes a second copy of the one above.
+    """
+    async with aiosqlite.connect(str(tmp_path / "legacy.db")) as conn:
+        conn.row_factory = aiosqlite.Row
+        await conn.execute("""
+            CREATE TABLE pending_outreach (
+                id                  TEXT PRIMARY KEY,
+                message             TEXT NOT NULL,
+                category            TEXT NOT NULL,
+                channel             TEXT NOT NULL DEFAULT 'telegram',
+                urgency             TEXT NOT NULL DEFAULT 'low',
+                deliver_after       TEXT,
+                created_at          TEXT NOT NULL,
+                delivered           INTEGER NOT NULL DEFAULT 0,
+                delivered_at        TEXT,
+                thread_id           TEXT,
+                validated_recipient TEXT
+            )
+        """)
+        # Deliberately post-0038 (thread_id present) but pre-labeled_surplus:
+        # ensure_table's legacy block heals exactly labeled_surplus and
+        # cancelled_at, so those two are what the fixture must be missing.
+        await conn.commit()
+
+        pre = {
+            row[1]
+            for row in await (await conn.execute("PRAGMA table_info(pending_outreach)")).fetchall()
+        }
+        assert "cancelled_at" not in pre, "fixture must start WITHOUT the column"
+
+        await pending_outreach.ensure_table(conn)
+
+        post = {
+            row[1]
+            for row in await (await conn.execute("PRAGMA table_info(pending_outreach)")).fetchall()
+        }
+        assert "cancelled_at" in post
+        assert "labeled_surplus" in post, "the pre-existing legacy ALTER must still fire"
+
+        # Idempotent: a second call must not raise "duplicate column name".
+        await pending_outreach.ensure_table(conn)
+
+        # And the new column is usable on the migrated table, not merely present.
+        pid = await pending_outreach.enqueue(conn, message="m", category="notification")
+        assert await pending_outreach.cancel(conn, pid) == (True, "cancelled")

--- a/tests/test_mcp/test_outreach_mcp.py
+++ b/tests/test_mcp/test_outreach_mcp.py
@@ -537,3 +537,50 @@ async def test_generic_outreach_send_forwards_labeled_surplus(tmp_path):
     finally:
         mcp_mod._pipeline, mcp_mod._db = old_pipeline, old_db
         await conn.close()
+
+
+async def test_outreach_pending_pages_with_a_denominator(tmp_path):
+    """The listing must report a TOTAL and a truncation flag, not a bare list.
+
+    A bare list capped at 50 is indistinguishable from a complete one. With 60
+    queued messages a caller would have concluded it had seen them all — and since
+    every id worth cancelling comes from this tool, the invisible rows were also
+    the uncancellable ones. Paging with `total` + `truncated` is the house shape
+    for a bounded read: whole elements, plus a denominator.
+    """
+    import aiosqlite
+
+    from genesis.db.crud import pending_outreach
+
+    old_pipeline, old_db = mcp_mod._pipeline, mcp_mod._db
+    async with aiosqlite.connect(str(tmp_path / "p.db")) as conn:
+        conn.row_factory = aiosqlite.Row
+        await pending_outreach.ensure_table(conn)
+        for i in range(60):
+            await pending_outreach.enqueue(
+                conn, message=f"queued {i}", category="notification",
+                deliver_after=f"2030-01-{(i % 28) + 1:02d}T00:00:00+00:00",
+            )
+        try:
+            mcp_mod._pipeline = None
+            mcp_mod._db = conn
+            tools = await mcp.get_tools()
+
+            first = await tools["outreach_pending"].fn()
+            assert first["total"] == 60, first
+            assert len(first["items"]) == 50
+            assert first["truncated"] is True, "60 rows behind a 50 cap must say so"
+
+            # The tail is REACHABLE, which is the point of paging.
+            rest = await tools["outreach_pending"].fn(offset=50)
+            assert len(rest["items"]) == 10
+            assert rest["truncated"] is False
+            ids = {r["id"] for r in first["items"]} | {r["id"] for r in rest["items"]}
+            assert len(ids) == 60, "paging lost or duplicated rows"
+
+            # A cancelled row leaves the listing AND the denominator.
+            await pending_outreach.cancel(conn, first["items"][0]["id"])
+            after = await tools["outreach_pending"].fn()
+            assert after["total"] == 59
+        finally:
+            mcp_mod._pipeline, mcp_mod._db = old_pipeline, old_db

--- a/tests/test_outreach/test_scheduler.py
+++ b/tests/test_outreach/test_scheduler.py
@@ -623,3 +623,59 @@ async def test_ambient_recovery_failing_alerts_with_remedy(config, db):
     text = scheduler._pipeline.submit_raw.call_args[0][0]
     assert "auto-recovery exhausted" in text
     assert "ESPHome API" in text  # the recovery-failing remedy hint
+
+
+@pytest.mark.asyncio
+async def test_drain_does_not_send_a_row_cancelled_after_the_snapshot(config, db):
+    """A cancel landing between drain and send must stop the send.
+
+    `drain` takes a snapshot of up to 20 rows and the loop then sends them one at a
+    time, each costing an LLM draft plus an adapter round-trip — so the snapshot is
+    stale by seconds to minutes. That is exactly when someone cancels: they cancel
+    because the message is about to go out. Without a re-read, cancel() reports
+    "cancelled", the message ships anyway, and the row ends up recorded as BOTH
+    cancelled and delivered — a contradiction no reader can resolve.
+
+    Simulated by cancelling from inside the pipeline's submit, which runs at the
+    same point in the sequence a concurrent cancel would.
+    """
+    from genesis.db.crud import pending_outreach
+
+    first = await pending_outreach.enqueue(
+        db, message="first", category="notification", channel="telegram"
+    )
+    second = await pending_outreach.enqueue(
+        db, message="second — cancelled while the first is in flight",
+        category="notification", channel="telegram",
+    )
+
+    pipeline = _drain_pipeline(OutreachStatus.DELIVERED)
+    original = pipeline.submit
+
+    async def _submit_then_cancel_the_next(req):
+        # Runs while row 1 is being sent — the real window.
+        await pending_outreach.cancel(db, second)
+        return await original(req)
+
+    pipeline.submit = AsyncMock(side_effect=_submit_then_cancel_the_next)
+    scheduler = OutreachScheduler(pipeline, AsyncMock(), AsyncMock(), config, db)
+
+    await scheduler._drain_pending_job()
+
+    sent = [c[0][0].context for c in pipeline.submit.call_args_list]
+    assert any("first" in m for m in sent), "the uncancelled row must still send"
+    assert not any("cancelled while" in m for m in sent), (
+        "the row cancelled after the drain snapshot was still sent — cancel() told "
+        "the caller it was cancelled and the recipient got it anyway"
+    )
+
+    cur = await db.execute(
+        "SELECT delivered, cancelled_at FROM pending_outreach WHERE id = ?", (second,)
+    )
+    row = await cur.fetchone()
+    assert row["cancelled_at"] is not None
+    assert row["delivered"] == 0, (
+        "a cancelled row must not also be marked delivered — that is the "
+        "contradictory record this guard exists to prevent"
+    )
+    assert first  # the id is used only to distinguish the two rows


### PR DESCRIPTION
## Problem

`pending_outreach` — the queue a foreground session writes to when it schedules a message for later — could express only two states: enqueued, or `delivered = 1`. There was no way to retract a queued message. Changing your mind left two options: let the stale message arrive and send a correction after it, or call `mark_delivered` on the original. That second one writes a record saying the recipient was told something they never were, into a table that gets read back — so a later session believes it.

## What this adds

- **`cancelled_at`** on `pending_outreach` (NULL = live). Additive, nullable, no backfill — a pre-existing row is by definition not cancelled, which is what NULL already means. All three schema paths carry it: `_tables.py` CREATE, `ensure_table`'s CREATE + legacy ALTER, and a numbered migration for existing installs.
- **`pending_outreach.cancel()`** → `(bool, reason)`. The WHERE clause is narrow (`id`, `delivered = 0`, `cancelled_at IS NULL`) so the bool means "I cancelled a live message", not "the row exists".
- **`outreach_pending`** — lists what is queued and when each item is due. It exists because `outreach_queue` reads `outreach_history` (already-delivered), so a scheduled message was addressable only by the id its `outreach_send` call returned; once that scrolled out of view it could not be found, inspected, or cancelled. It simply arrived.
- **`outreach_cancel(pending_id)`** — retracts one by id.

`drain` gained the same predicate. It is the only pending-state SELECT over the table — enumerated across the tree rather than spot-checked (23 files mention the table; the only production `delivered = 0` predicates are the two in the CRUD module).

**One nullable timestamp, not a flag + timestamp pair**, deliberately diverging from the `delivered`/`delivered_at` pair directly above it: this way "cancelled with no timestamp" is unrepresentable. Commented at both schema sites so a future cleanup doesn't "fix" the inconsistency back into a bad state.

## What the adversarial audit changed

An internal audit was asked to assume the change was buggy and attack seven named claims. Three findings were defects in the first draft; all are fixed here.

**`delivered = 1` does not mean sent.** The drain writes it for `HELD` (handed to the autonomy gate, awaiting owner approval — and it *will* send afterwards), for `IGNORED`, and for the 24h age-out whose own log line reads "never delivered". The first draft's reason string said "already delivered, it cannot be un-sent" — false in the HELD case, which is precisely the window where someone wants to retract. `cancel()` now distinguishes `already_cancelled` / `unknown_id` / `already_dequeued`, and the last one says "sent, awaiting approval at the autonomy gate, or aged out. Not necessarily delivered." Making `delivered` stop meaning two things is a scheduler-wide fix, deliberately not smuggled in here.

**The drain now re-reads cancel state immediately before sending.** `drain` snapshots up to 20 rows and the loop sends them one at a time, each costing an LLM draft and an adapter round-trip, so the snapshot is stale by seconds to minutes — and that is exactly when a cancel arrives, because people cancel when a message is about to go out. Without the re-read, `cancel()` returned "cancelled" and the message shipped anyway, leaving a row recorded as *both* cancelled and delivered, which no later reader can resolve. A microsecond race remains between the re-read and the send; that one is inherent without row locking and is stated as such in the code.

**`outreach_pending`'s ORDER BY listed the due-now rows last.** A NULL `deliver_after` means "goes out on the next tick", and `(deliver_after IS NULL) ASC` sorted those *after* everything scheduled for next month — so past 50 rows the LIMIT discarded precisely the messages worth cancelling, while the docstring claimed "soonest-due first".

Also: `ensure_table`'s two ALTERs no longer share one exception guard. A lost lock on the first silently skipped the second, and a missing `cancelled_at` does not degrade one flag — it breaks `drain`'s WHERE clause, stopping the whole queue behind a single caught log line.

## Perimeter tool reach — a security fix, and a polarity change

The audit found both new tools reachable from the profiles that process untrusted inbound content. Session profiles are **deny** lists, so a tool nobody enumerates is allowed; the perimeter profile's own comment claims "only `outreach_send` is available", which described an intended result the mechanism never enforced. An injected inbound message could have listed the queue (50 message previews — an exfiltration surface) and cancelled the owner's queued alerts.

Rather than only naming the two new tools, the boundary is now stated as an **allowlist in a test**: enumerate what the outreach server actually registers, and require the perimeter profiles to deny everything outside an explicitly-reasoned allowed set. A new tool fails that test until someone places it.

That test failed on its first run, for tools this change never touched:

- `provision_grow` / `provision_vzdump` — host-capacity actuators, reachable from the perimeter. Both are approval-gated (nothing mutates without an explicit APPROVE from the owner), so this was never a silent-compromise path and is not being described as one. It is still wrong that injected content could raise plausible infrastructure approval prompts.
- The **community-message** perimeter profile carried *neither* outreach deny group, though it mounts the outreach server and is classified as external-ingesting. The whole surface beyond send was reachable from that side. The email profile had the same shape and was covered; this one was simply never given the groups.

Both fixed here rather than filed, per the standing rule that a security defect is not posted publicly before it is fixed.

## Verification

- Mutation-verified **6/6**: each new invariant broken in turn, with the naming test confirmed to go red and the file restored under hash comparison.
- One mutation is why the test set grew. The original `ensure_table` assertion ran against a *fresh* database, where CREATE TABLE already carries the column — so the legacy-ALTER branch that every existing install takes had zero coverage, while a green test next to it claimed otherwise. Both that branch and the numbered migration are now pinned by tests that go red when their ALTER is removed.
- 247 tests green across the six affected files.
- `AGENTS.md` tool inventory regenerated (auto-generated, not CI-gated, and it had drifted on three unrelated entries too).

E2E: after merge + deploy, restart a session so the MCP subprocess picks up the new tools, then run the real round-trip — `outreach_send` with a future `preferred_timing`, confirm `outreach_pending` lists it, `outreach_cancel` it, and confirm the scheduler drain skips it and nothing arrives. The tools cannot be exercised live pre-merge because MCP servers are CC child processes.
