### PR TITLE
fix(memory): resolve the short id handles a supersede is given

### DIFF
--- a/changelog.d/20260910190000-fixed-supersede-short-handle-resolution.md
+++ b/changelog.d/20260910190000-fixed-supersede-short-handle-resolution.md
@@ -15,6 +15,11 @@
 
   `supersedes` now accepts the same short handles the rest of the system hands
   out, never guesses an ambiguous one, and refuses a full-length id that names
-  no memory instead of writing a dangling edge and reporting nothing. A
-  supersede that cannot resolve its target is rejected before anything is
-  written, so it can no longer leave half an operation behind.
+  no memory instead of writing a dangling edge and reporting nothing.
+
+  The target is resolved **before the new memory is written**, which is what
+  makes the rejection cheap and total: nothing is stored, nothing is linked, and
+  there is no half-completed operation for the caller to reason about. That
+  ordering also removes a way the old code could corrupt a memory outright --
+  resolving after the write meant a short handle could match the row the call
+  had just created and deprecate the new memory as its own successor.

--- a/changelog.d/20260910190000-fixed-supersede-short-handle-resolution.md
+++ b/changelog.d/20260910190000-fixed-supersede-short-handle-resolution.md
@@ -1,0 +1,20 @@
+- **Correcting a memory with a short id handle did nothing, silently.**
+  `memory_store` accepts a `supersedes` id, and the proactive recall hook prints
+  memories as short `id:<8-char>` handles -- but only the READ path
+  (`memory_expand`) resolved those handles. On the write path the handle went
+  into an exact-match update, matched nothing, and the "did I find it" answer
+  was thrown away. The call returned an id, so the caller read success, while
+  the stale memory stayed live in recall and the only trace was a `succeeded_by`
+  graph edge pointing from something that was not a memory.
+
+  Measured on one install: three such edges inside one 14-minute window, none
+  ever before, and every one of the three handles named exactly one memory --
+  resolution alone would have prevented all three. Two of them were retried with
+  the full id about ninety seconds later, so the silence also duplicated the
+  correction; the third was simply lost.
+
+  `supersedes` now accepts the same short handles the rest of the system hands
+  out, never guesses an ambiguous one, and refuses a full-length id that names
+  no memory instead of writing a dangling edge and reporting nothing. A
+  supersede that cannot resolve its target is rejected before anything is
+  written, so it can no longer leave half an operation behind.

--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -472,6 +472,37 @@ async def invalidate_memory(
     return cursor.rowcount > 0
 
 
+async def resolve_id(db: aiosqlite.Connection, id_or_prefix: str) -> tuple[list[str], str]:
+    """Resolve a full memory id OR a short hex handle to the memory row(s).
+
+    Thin wrapper over the shared resolver so WRITE paths accept the same short
+    handles the READ paths already do. ``memory_expand`` resolves ``id:<8-char>``
+    handles because the proactive hook hands them out
+    (``mcp/memory/core.py::_resolve_id_prefixes``); ``supersedes`` did not, so an
+    8-char handle hit an exact-match UPDATE, matched nothing, and the caller was
+    told the store succeeded.
+
+    ``full_len=36`` — memory ids are DASHED uuid4 (36 chars), not the 32-char
+    ``uuid4().hex`` the resolver defaults to. NOTE the mechanism, because the
+    obvious reading is wrong: a COMPLETE 36-char id is PASSTHROUGH under either
+    value (``len(mid) >= full_len`` is true at 32 as well). What ``36`` actually
+    changes is the 32-to-35-char band — a TRUNCATED paste of a real id, which
+    the default would wave through as "full length" into an exact-match lookup
+    that cannot hit, and which 36 lets prefix-resolve instead.
+
+    Returns ``(matches, outcome)`` — see ``crud/_id_resolve``.
+    """
+    from genesis.db.crud._id_resolve import resolve_unique_prefix
+
+    return await resolve_unique_prefix(
+        db,
+        table="memory_metadata",
+        id_column="memory_id",
+        raw_id=id_or_prefix,
+        full_len=36,
+    )
+
+
 async def mark_superseded(
     db: aiosqlite.Connection,
     old_id: str,

--- a/src/genesis/memory/store.py
+++ b/src/genesis/memory/store.py
@@ -12,6 +12,8 @@ from genesis.db.crud import entities as entities_crud
 from genesis.db.crud import memory as memory_crud
 from genesis.db.crud import memory_links as memory_links_crud
 from genesis.db.crud import pending_embeddings
+from genesis.db.crud._id_resolve import AMBIGUOUS as _AMBIGUOUS
+from genesis.db.crud._id_resolve import NOT_FOUND as _NOT_FOUND
 from genesis.memory._locks import memory_id_lock
 from genesis.memory.classification import classify_memory
 from genesis.memory.embeddings import EmbeddingProvider, EmbeddingUnavailableError
@@ -43,6 +45,10 @@ except ImportError:  # pragma: no cover — safety for minimal installs
 
 logger = logging.getLogger(__name__)
 
+# _id_resolve.resolve_unique_prefix reads with LIMIT 3; a result at that
+# size is a truncated listing, so the candidate set may be incomplete.
+_RESOLVER_MATCH_LIMIT = 3
+
 
 def _strip_kv_prefix(value: str | None, key: str) -> str | None:
     """Strip a leaked ``key=`` / ``key:`` prefix from a taxonomy value.
@@ -67,6 +73,48 @@ _COLLECTION_MAP = {
     "episodic": "episodic_memory",
     "knowledge": "knowledge_base",  # External knowledge → knowledge_base
 }
+
+
+class SupersedeUnresolved(Exception):
+    """``supersedes`` named no memory, or named several.
+
+    Raised BEFORE ``_mark_superseded`` writes anything, and — on the ``store()``
+    path — AFTER the new memory is durably stored, so it describes a partial
+    outcome rather than a failed write: the content is safe, the deprecation did
+    not happen.
+
+    Never guess an ambiguous handle: two memories sharing a prefix are two
+    different corrections, and deprecating the wrong one is unrecoverable
+    without the transcript.
+    """
+
+    def __init__(
+        self,
+        raw_id: str,
+        reason: str,
+        stored_memory_id: str,
+        candidates: list[str] | None = None,
+        truncated: bool = False,
+    ):
+        self.raw_id = raw_id
+        self.reason = reason  # "not_found" | "ambiguous"
+        # The memory that DID land. Carried so a reporting layer can hand the
+        # caller its id without a second lookup — without it the caller has a
+        # failure and no handle on the content it just wrote.
+        self.stored_memory_id = stored_memory_id
+        self.candidates = candidates or []
+        # The resolver reads with LIMIT 3, so a saturated result is a TRUNCATED
+        # listing, not the complete collision set. Saying "matches: a, b, c"
+        # about ten colliding memories is the repo's own truncated-read trap.
+        self.truncated = truncated
+        more = " (possibly more)" if truncated else ""
+        detail = (
+            f" (matches: {', '.join(self.candidates)}{more})" if self.candidates else ""
+        )
+        super().__init__(
+            f"supersedes={raw_id!r} is {reason}{detail}; "
+            f"memory {stored_memory_id} WAS stored"
+        )
 
 
 class MemoryStore:
@@ -503,9 +551,34 @@ class MemoryStore:
         Sets ``deprecated=1``, ``superseded_by``, and ``superseded_at`` in
         SQLite.  Sets ``deprecated=True`` and ``merged_into`` in the Qdrant
         payload.  Creates a ``succeeded_by`` link from old to new.
+
+        Raises ``SupersedeUnresolved`` — BEFORE any write — when *old_id* names
+        no memory or names several. Nothing is mutated on that path, so an
+        unresolvable handle can no longer leave a ``succeeded_by`` edge whose
+        source is not a memory (the only artifact the broken path used to
+        produce).
         """
-        # SQLite: mark deprecated + record successor (via CRUD module)
-        await memory_crud.mark_superseded(self._db, old_id, new_id, timestamp)
+        # Resolve short handles FIRST. The proactive hook prints memories as
+        # `id:<8-char>` and memory_expand resolves those on the read side, so
+        # the ecosystem teaches the short form; this path used to feed it
+        # straight into an exact-match UPDATE that matched nothing.
+        matches, outcome = await memory_crud.resolve_id(self._db, old_id)
+        if outcome == _AMBIGUOUS:
+            raise SupersedeUnresolved(
+                old_id, "ambiguous", new_id, matches,
+                truncated=len(matches) >= _RESOLVER_MATCH_LIMIT,
+            )
+        if outcome == _NOT_FOUND:
+            raise SupersedeUnresolved(old_id, "not_found", new_id)
+        old_id = matches[0]
+
+        # SQLite: mark deprecated + record successor (via CRUD module).
+        # The return value says whether the row was FOUND — discarding it was
+        # how an unresolvable id became a silent no-op. PASSTHROUGH ids (full
+        # length, or non-hex) reach here unverified by design, so this is the
+        # check that catches them.
+        if not await memory_crud.mark_superseded(self._db, old_id, new_id, timestamp):
+            raise SupersedeUnresolved(old_id, "not_found", new_id)
 
         # Qdrant: look up collection from metadata, then update payload.
         # Only touch Qdrant when a vector actually exists (status 'embedded').

--- a/src/genesis/memory/store.py
+++ b/src/genesis/memory/store.py
@@ -14,6 +14,7 @@ from genesis.db.crud import memory_links as memory_links_crud
 from genesis.db.crud import pending_embeddings
 from genesis.db.crud._id_resolve import AMBIGUOUS as _AMBIGUOUS
 from genesis.db.crud._id_resolve import NOT_FOUND as _NOT_FOUND
+from genesis.db.crud._id_resolve import PASSTHROUGH as _PASSTHROUGH
 from genesis.memory._locks import memory_id_lock
 from genesis.memory.classification import classify_memory
 from genesis.memory.embeddings import EmbeddingProvider, EmbeddingUnavailableError
@@ -92,16 +93,17 @@ class SupersedeUnresolved(Exception):
         self,
         raw_id: str,
         reason: str,
-        stored_memory_id: str,
+        successor_id: str | None = None,
         candidates: list[str] | None = None,
         truncated: bool = False,
     ):
         self.raw_id = raw_id
         self.reason = reason  # "not_found" | "ambiguous"
-        # The memory that DID land. Carried so a reporting layer can hand the
-        # caller its id without a second lookup — without it the caller has a
-        # failure and no handle on the content it just wrote.
-        self.stored_memory_id = stored_memory_id
+        # The memory that WOULD have become the successor, when one is known.
+        # Deliberately optional: validation now runs BEFORE any write, so on the
+        # ``store()`` path there is usually no successor yet — and nothing
+        # durable at risk, which is why this can be a plain raise.
+        self.successor_id = successor_id
         self.candidates = candidates or []
         # The resolver reads with LIMIT 3, so a saturated result is a TRUNCATED
         # listing, not the complete collision set. Saying "matches: a, b, c"
@@ -111,9 +113,12 @@ class SupersedeUnresolved(Exception):
         detail = (
             f" (matches: {', '.join(self.candidates)}{more})" if self.candidates else ""
         )
+        # States only what was CHECKED. The old wording claimed the old memory
+        # "is still live in recall", which for `not_found` is exactly the thing
+        # resolution just failed to establish.
         super().__init__(
             f"supersedes={raw_id!r} is {reason}{detail}; "
-            f"memory {stored_memory_id} WAS stored"
+            "no deprecation was performed"
         )
 
 
@@ -255,6 +260,16 @@ class MemoryStore:
         is_subsystem_write = source_subsystem is not None
         if is_subsystem_write:
             force_fts5_only = True
+
+        # Resolve the supersede target BEFORE anything is written. An
+        # unresolvable target then costs nothing and leaves nothing behind, and
+        # the raise reaches the caller with no half-done operation attached.
+        # It also has to be before ``create_metadata``: resolving afterwards let
+        # a short prefix match the row this call had just written, deprecating
+        # the new memory as its own successor.
+        resolved_supersedes = (
+            await self._resolve_supersede_target(supersedes) if supersedes else None
+        )
 
         memory_id = str(uuid.uuid4())
         now_iso = datetime.now(UTC).isoformat()
@@ -528,17 +543,62 @@ class MemoryStore:
         # else: subsystem write — no pending_embeddings, no auto_link
         # (vector wasn't computed; link graph isn't consumed for filtered content)
 
-        # Supersession: mark old memory as deprecated, link to this one
-        if supersedes:
+        # Supersession: mark old memory as deprecated, link to this one. The
+        # target was resolved and confirmed to exist before any of the writes
+        # above, so anything that fails here is an infrastructure fault rather
+        # than a bad handle.
+        if resolved_supersedes:
             try:
-                await self._mark_superseded(supersedes, memory_id, now_iso)
+                await self._mark_superseded(resolved_supersedes, memory_id, now_iso)
             except Exception:
                 logger.warning(
                     "Failed to mark memory %s as superseded by %s",
-                    supersedes, memory_id, exc_info=True,
+                    resolved_supersedes, memory_id, exc_info=True,
                 )
 
         return memory_id
+
+    async def _resolve_supersede_target(self, handle: str) -> str:
+        """Resolve a ``supersedes`` handle to exactly one EXISTING memory id.
+
+        Reads only — it writes nothing and must be called BEFORE the store does,
+        so an unresolvable target costs nothing and leaves nothing behind. That
+        ordering is load-bearing twice over:
+
+        * The old code resolved AFTER ``create_metadata`` had written the new
+          row, so a short prefix could match the memory being written and the
+          call would deprecate it as its own successor. Resolving first makes
+          that unrepresentable — the row does not exist yet — rather than
+          needing a guard against it.
+        * Nothing durable is at risk when this raises, so the caller can simply
+          be told, instead of being handed a half-completed operation to
+          reason about.
+
+        The proactive hook prints memories as ``id:<8-char>`` and
+        ``memory_expand`` resolves those on the read side, so the ecosystem
+        teaches the short form; this path used to feed it straight into an
+        exact-match UPDATE that matched nothing.
+        """
+        matches, outcome = await memory_crud.resolve_id(self._db, handle)
+        if outcome == _AMBIGUOUS:
+            raise SupersedeUnresolved(
+                handle, "ambiguous", candidates=matches,
+                truncated=len(matches) >= _RESOLVER_MATCH_LIMIT,
+            )
+        if outcome == _NOT_FOUND:
+            raise SupersedeUnresolved(handle, "not_found")
+        resolved = matches[0]
+
+        # PASSTHROUGH ids (full length, or non-hex) are returned unverified by
+        # the shared resolver — it never looked them up. Confirm existence HERE
+        # so every rejection happens before the write; otherwise a full-length
+        # id naming no memory would only be caught by the UPDATE's rowcount,
+        # which is after the new memory has been stored.
+        if outcome == _PASSTHROUGH and await memory_crud.get_metadata(
+            self._db, resolved
+        ) is None:
+            raise SupersedeUnresolved(handle, "not_found")
+        return resolved
 
     async def _mark_superseded(
         self,
@@ -548,35 +608,19 @@ class MemoryStore:
     ) -> None:
         """Mark *old_id* as superseded by *new_id* in both SQLite and Qdrant.
 
+        *old_id* must ALREADY be resolved and known to exist — see
+        ``_resolve_supersede_target``, which the caller runs before any write.
+
         Sets ``deprecated=1``, ``superseded_by``, and ``superseded_at`` in
         SQLite.  Sets ``deprecated=True`` and ``merged_into`` in the Qdrant
         payload.  Creates a ``succeeded_by`` link from old to new.
-
-        Raises ``SupersedeUnresolved`` — BEFORE any write — when *old_id* names
-        no memory or names several. Nothing is mutated on that path, so an
-        unresolvable handle can no longer leave a ``succeeded_by`` edge whose
-        source is not a memory (the only artifact the broken path used to
-        produce).
         """
-        # Resolve short handles FIRST. The proactive hook prints memories as
-        # `id:<8-char>` and memory_expand resolves those on the read side, so
-        # the ecosystem teaches the short form; this path used to feed it
-        # straight into an exact-match UPDATE that matched nothing.
-        matches, outcome = await memory_crud.resolve_id(self._db, old_id)
-        if outcome == _AMBIGUOUS:
-            raise SupersedeUnresolved(
-                old_id, "ambiguous", new_id, matches,
-                truncated=len(matches) >= _RESOLVER_MATCH_LIMIT,
-            )
-        if outcome == _NOT_FOUND:
-            raise SupersedeUnresolved(old_id, "not_found", new_id)
-        old_id = matches[0]
-
         # SQLite: mark deprecated + record successor (via CRUD module).
         # The return value says whether the row was FOUND — discarding it was
-        # how an unresolvable id became a silent no-op. PASSTHROUGH ids (full
-        # length, or non-hex) reach here unverified by design, so this is the
-        # check that catches them.
+        # how an unresolvable id became a silent no-op. `_resolve_supersede_target`
+        # has already established that the row exists, so reaching this branch
+        # means it was deleted in the window between the two — a race, not a bad
+        # handle. Kept because a silent no-op here is the original defect.
         if not await memory_crud.mark_superseded(self._db, old_id, new_id, timestamp):
             raise SupersedeUnresolved(old_id, "not_found", new_id)
 

--- a/src/genesis/memory/store.py
+++ b/src/genesis/memory/store.py
@@ -79,10 +79,10 @@ _COLLECTION_MAP = {
 class SupersedeUnresolved(Exception):
     """``supersedes`` named no memory, or named several.
 
-    Raised BEFORE ``_mark_superseded`` writes anything, and — on the ``store()``
-    path — AFTER the new memory is durably stored, so it describes a partial
-    outcome rather than a failed write: the content is safe, the deprecation did
-    not happen.
+    Raised BEFORE ``_mark_superseded`` writes anything. When propagated to
+    the caller by ``store()``, it reports a target-resolution preflight failure,
+    before generating the new memory ID or writing the new memory. Neither
+    the new content nor a deprecation has been stored by that call.
 
     Never guess an ambiguous handle: two memories sharing a prefix are two
     different corrections, and deprecating the wrong one is unrecoverable

--- a/tests/test_memory/test_supersede_prefix_resolution.py
+++ b/tests/test_memory/test_supersede_prefix_resolution.py
@@ -1,0 +1,245 @@
+"""memory_store(supersedes=...) must resolve the short handles the ecosystem hands out.
+
+The proactive recall hook prints memories as ``id:<8-char-prefix>`` and
+``memory_expand`` resolves those handles on the READ side
+(``mcp/memory/core.py::_resolve_id_prefixes``, whose docstring says the handles
+"must resolve here"). The WRITE side never got the same treatment: ``supersedes``
+went to an exact-match UPDATE that matched nothing, ``mark_superseded``'s
+"did I find it" return value was discarded, and the only artifact of the whole
+operation was a dangling ``succeeded_by`` edge whose source is not a memory.
+
+MEASURED on the live DB 2026-09-06: three such rows created in a 14-minute
+window (0 historically); one of the three targets is still ``deprecated=0``,
+i.e. a memory that a session believed it had corrected is still live in recall.
+Every one of the three handles resolved to exactly one memory, so resolution
+alone would have prevented all three.
+
+Real SQLite here, not mocks — the defect IS which rows the SQL matches, and a
+mocked connection would happily confirm whatever the test asserted.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import aiosqlite
+import pytest
+
+from genesis.memory.store import MemoryStore
+
+OLD = "abcd1234-0000-4000-8000-000000000001"
+NEW = "efab5678-0000-4000-8000-000000000002"
+PREFIX = OLD[:8]
+
+
+@pytest.fixture()
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    # DDL copied from production (sqlite_master, 2026-09-06) rather than
+    # hand-rolled: a fixture missing MW-2's proposed_type made the regression
+    # lock fail for the WRONG reason on the first RED run, which proves nothing.
+    await conn.execute(
+        """CREATE TABLE memory_metadata (
+               memory_id        TEXT PRIMARY KEY,
+               created_at       TEXT NOT NULL,
+               collection       TEXT NOT NULL DEFAULT 'episodic_memory',
+               confidence       REAL,
+               embedding_status TEXT NOT NULL DEFAULT 'embedded',
+               memory_class TEXT DEFAULT 'fact', wing TEXT, room TEXT,
+               valid_at TEXT, invalid_at TEXT, source_subsystem TEXT,
+               deprecated INTEGER NOT NULL DEFAULT 0, dream_cycle_run_id TEXT,
+               superseded_by TEXT, superseded_at TEXT, origin_class TEXT,
+               provenance_class TEXT, trust_level TEXT, attribution TEXT,
+               origin_ref TEXT, capture_clarity REAL, deprecated_at TEXT,
+               speech_act TEXT, speech_act_confidence REAL,
+               assertion_provenance TEXT, durability TEXT, expires_at TEXT
+           )"""
+    )
+    await conn.execute(
+        """CREATE TABLE memory_links (
+               source_id   TEXT NOT NULL,
+               target_id   TEXT NOT NULL,
+               link_type   TEXT NOT NULL CHECK (
+                   link_type IN (
+                       'supports','contradicts','extends','elaborates',
+                       'discussed_in','evaluated_for','decided',
+                       'action_item_for','categorized_as','related_to',
+                       'succeeded_by','preceded_by'
+                   )
+               ),
+               strength    REAL NOT NULL DEFAULT 0.5,
+               created_at  TEXT NOT NULL,
+               proposed_type TEXT, confidence REAL, classifier TEXT,
+               review_state TEXT, safe_for_boost INTEGER,
+               PRIMARY KEY (source_id, target_id, link_type)
+           )"""
+    )
+    for mid in (OLD, NEW):
+        await conn.execute(
+            "INSERT INTO memory_metadata (memory_id, created_at, embedding_status) "
+            "VALUES (?, '2026-09-06T00:00:00+00:00', 'fts5_only')",
+            (mid,),
+        )
+    await conn.commit()
+    yield conn
+    await conn.close()
+
+
+@pytest.fixture()
+def store(db):
+    ep = MagicMock()
+    ep.embed = AsyncMock(return_value=[0.1] * 1024)
+    return MemoryStore(
+        embedding_provider=ep,
+        qdrant_client=MagicMock(),
+        db=db,
+        linker=MagicMock(),
+    )
+
+
+async def _row(db, mid):
+    cur = await db.execute(
+        "SELECT deprecated, superseded_by FROM memory_metadata WHERE memory_id = ?",
+        (mid,),
+    )
+    return await cur.fetchone()
+
+
+async def _links(db):
+    cur = await db.execute("SELECT source_id, target_id, link_type FROM memory_links")
+    return [tuple(r) for r in await cur.fetchall()]
+
+
+@pytest.mark.asyncio()
+async def test_eight_char_prefix_deprecates_the_memory_it_names(store, db):
+    """THE LIVE BUG: an 8-char handle must supersede, not silently no-op."""
+    await store._mark_superseded(PREFIX, NEW, "2026-09-06T19:53:21+00:00")
+
+    row = await _row(db, OLD)
+    assert row["deprecated"] == 1, (
+        f"supersedes={PREFIX!r} left the memory live — this is the measured "
+        "live defect: the caller was told the store succeeded."
+    )
+    assert row["superseded_by"] == NEW
+
+
+@pytest.mark.asyncio()
+async def test_prefix_never_becomes_a_dangling_link_source(store, db):
+    """The only artifact of the broken path was an edge from a non-memory."""
+    await store._mark_superseded(PREFIX, NEW, "2026-09-06T19:53:21+00:00")
+
+    links = await _links(db)
+    assert (PREFIX, NEW, "succeeded_by") not in links, (
+        "wrote a succeeded_by edge whose source is an 8-char prefix, not a memory"
+    )
+    assert (OLD, NEW, "succeeded_by") in links
+
+
+@pytest.mark.asyncio()
+async def test_unknown_id_is_reported_not_swallowed(store, db):
+    """A prefix matching nothing must be LOUD — today it is silent."""
+    from genesis.memory.store import SupersedeUnresolved
+
+    with pytest.raises(SupersedeUnresolved) as exc:
+        await store._mark_superseded("deadbeef", NEW, "2026-09-06T19:53:21+00:00")
+
+    assert exc.value.reason == "not_found"
+    assert exc.value.stored_memory_id == NEW, "caller needs a handle on what DID land"
+    assert await _links(db) == [], "no edge may be written for an unresolved target"
+
+
+@pytest.mark.asyncio()
+async def test_ambiguous_prefix_is_never_guessed(store, db):
+    """Two memories share a prefix — supersede neither, name both."""
+    from genesis.memory.store import SupersedeUnresolved
+
+    twin = OLD[:8] + "-0000-0000-0000-000000000000"
+    await db.execute(
+        "INSERT INTO memory_metadata (memory_id, created_at, embedding_status) "
+        "VALUES (?, '2026-09-06T00:00:00+00:00', 'fts5_only')",
+        (twin,),
+    )
+    await db.commit()
+
+    with pytest.raises(SupersedeUnresolved) as exc:
+        await store._mark_superseded(PREFIX, NEW, "2026-09-06T19:53:21+00:00")
+
+    assert exc.value.reason == "ambiguous"
+    assert set(exc.value.candidates) == {OLD, twin}
+    assert (await _row(db, OLD))["deprecated"] == 0
+    assert (await _row(db, twin))["deprecated"] == 0
+    assert await _links(db) == []
+
+
+@pytest.mark.asyncio()
+async def test_full_id_still_works(store, db):
+    """Regression lock: the 36-char path is unchanged."""
+    await store._mark_superseded(OLD, NEW, "2026-09-06T19:53:21+00:00")
+
+    assert (await _row(db, OLD))["deprecated"] == 1
+    assert (OLD, NEW, "succeeded_by") in await _links(db)
+
+
+@pytest.mark.asyncio()
+async def test_a_full_id_naming_no_memory_is_reported_not_swallowed(store, db):
+    """The PASSTHROUGH hole: a 36-char id skips resolution entirely.
+
+    ``resolve_unique_prefix`` returns PASSTHROUGH for anything full-length or
+    non-hex, so those ids reach the UPDATE unverified and ``mark_superseded``'s
+    return is the ONLY thing that catches them. Deleting that check leaves every
+    other test in this file green — they either hand the resolver a prefix
+    (caught earlier, at NOT_FOUND) or name a row that exists.
+    """
+    from genesis.memory.store import SupersedeUnresolved
+
+    ghost = "deadbeef-0000-4000-8000-000000000009"  # 36 chars, no such row
+    with pytest.raises(SupersedeUnresolved) as exc:
+        await store._mark_superseded(ghost, NEW, "2026-09-06T19:53:21+00:00")
+
+    assert exc.value.reason == "not_found"
+    assert await _links(db) == [], "no succeeded_by edge may be written"
+
+
+@pytest.mark.asyncio()
+async def test_a_truncated_paste_in_the_32_to_35_band_resolves(store, db):
+    """Locks ``full_len=36``, and pins the band that value actually changes.
+
+    A COMPLETE 36-char id is PASSTHROUGH under either full_len, so it cannot
+    lock this parameter. The 32-to-35 band is the real difference: under the
+    resolver's default of 32 such a truncation counts as full-length and goes
+    to an exact-match lookup that cannot hit.
+    """
+    truncated = OLD[:33]
+    assert 32 <= len(truncated) < 36, "fixture must sit in the band under test"
+
+    await store._mark_superseded(truncated, NEW, "2026-09-06T19:53:21+00:00")
+
+    assert (await _row(db, OLD))["deprecated"] == 1
+    assert (OLD, NEW, "succeeded_by") in await _links(db)
+
+
+@pytest.mark.asyncio()
+async def test_a_saturated_candidate_list_is_flagged_as_truncated(store, db):
+    """The resolver reads with LIMIT 3, so 3 matches may mean "3 or more".
+
+    Reporting three ids as though they were the whole collision set is the
+    truncated-listing trap: the caller cannot tell a complete answer from a
+    clipped one unless the clip is declared.
+    """
+    from genesis.memory.store import SupersedeUnresolved
+
+    for n in range(3):
+        await db.execute(
+            "INSERT INTO memory_metadata (memory_id, created_at, embedding_status) "
+            "VALUES (?, '2026-09-06T00:00:00+00:00', 'fts5_only')",
+            (f"{OLD[:8]}-ffff-4000-8000-00000000000{n}",),
+        )
+    await db.commit()
+
+    with pytest.raises(SupersedeUnresolved) as exc:
+        await store._mark_superseded(OLD[:8], NEW, "2026-09-06T19:53:21+00:00")
+
+    assert exc.value.reason == "ambiguous"
+    assert exc.value.truncated is True
+    assert "possibly more" in str(exc.value)

--- a/tests/test_memory/test_supersede_prefix_resolution.py
+++ b/tests/test_memory/test_supersede_prefix_resolution.py
@@ -111,10 +111,21 @@ async def _links(db):
     return [tuple(r) for r in await cur.fetchall()]
 
 
+async def _supersede(store, handle, new_id, ts):
+    """Resolve then mark, in the order ``store()`` does it.
+
+    Resolution is a SEPARATE step that runs before any write. Driving the two
+    together here keeps these tests on the real call order rather than on a
+    combined method that no longer exists.
+    """
+    resolved = await store._resolve_supersede_target(handle)
+    return await store._mark_superseded(resolved, new_id, ts)
+
+
 @pytest.mark.asyncio()
 async def test_eight_char_prefix_deprecates_the_memory_it_names(store, db):
     """THE LIVE BUG: an 8-char handle must supersede, not silently no-op."""
-    await store._mark_superseded(PREFIX, NEW, "2026-09-06T19:53:21+00:00")
+    await _supersede(store, PREFIX, NEW, "2026-09-06T19:53:21+00:00")
 
     row = await _row(db, OLD)
     assert row["deprecated"] == 1, (
@@ -127,7 +138,7 @@ async def test_eight_char_prefix_deprecates_the_memory_it_names(store, db):
 @pytest.mark.asyncio()
 async def test_prefix_never_becomes_a_dangling_link_source(store, db):
     """The only artifact of the broken path was an edge from a non-memory."""
-    await store._mark_superseded(PREFIX, NEW, "2026-09-06T19:53:21+00:00")
+    await _supersede(store, PREFIX, NEW, "2026-09-06T19:53:21+00:00")
 
     links = await _links(db)
     assert (PREFIX, NEW, "succeeded_by") not in links, (
@@ -142,10 +153,12 @@ async def test_unknown_id_is_reported_not_swallowed(store, db):
     from genesis.memory.store import SupersedeUnresolved
 
     with pytest.raises(SupersedeUnresolved) as exc:
-        await store._mark_superseded("deadbeef", NEW, "2026-09-06T19:53:21+00:00")
+        await _supersede(store, "deadbeef", NEW, "2026-09-06T19:53:21+00:00")
 
     assert exc.value.reason == "not_found"
-    assert exc.value.stored_memory_id == NEW, "caller needs a handle on what DID land"
+    # Nothing is stored and nothing is claimed about the target's recall state —
+    # resolution is exactly what just failed to establish it.
+    assert "no deprecation was performed" in str(exc.value)
     assert await _links(db) == [], "no edge may be written for an unresolved target"
 
 
@@ -163,7 +176,7 @@ async def test_ambiguous_prefix_is_never_guessed(store, db):
     await db.commit()
 
     with pytest.raises(SupersedeUnresolved) as exc:
-        await store._mark_superseded(PREFIX, NEW, "2026-09-06T19:53:21+00:00")
+        await _supersede(store, PREFIX, NEW, "2026-09-06T19:53:21+00:00")
 
     assert exc.value.reason == "ambiguous"
     assert set(exc.value.candidates) == {OLD, twin}
@@ -175,7 +188,7 @@ async def test_ambiguous_prefix_is_never_guessed(store, db):
 @pytest.mark.asyncio()
 async def test_full_id_still_works(store, db):
     """Regression lock: the 36-char path is unchanged."""
-    await store._mark_superseded(OLD, NEW, "2026-09-06T19:53:21+00:00")
+    await _supersede(store, OLD, NEW, "2026-09-06T19:53:21+00:00")
 
     assert (await _row(db, OLD))["deprecated"] == 1
     assert (OLD, NEW, "succeeded_by") in await _links(db)
@@ -195,7 +208,7 @@ async def test_a_full_id_naming_no_memory_is_reported_not_swallowed(store, db):
 
     ghost = "deadbeef-0000-4000-8000-000000000009"  # 36 chars, no such row
     with pytest.raises(SupersedeUnresolved) as exc:
-        await store._mark_superseded(ghost, NEW, "2026-09-06T19:53:21+00:00")
+        await _supersede(store, ghost, NEW, "2026-09-06T19:53:21+00:00")
 
     assert exc.value.reason == "not_found"
     assert await _links(db) == [], "no succeeded_by edge may be written"
@@ -213,7 +226,7 @@ async def test_a_truncated_paste_in_the_32_to_35_band_resolves(store, db):
     truncated = OLD[:33]
     assert 32 <= len(truncated) < 36, "fixture must sit in the band under test"
 
-    await store._mark_superseded(truncated, NEW, "2026-09-06T19:53:21+00:00")
+    await _supersede(store, truncated, NEW, "2026-09-06T19:53:21+00:00")
 
     assert (await _row(db, OLD))["deprecated"] == 1
     assert (OLD, NEW, "succeeded_by") in await _links(db)
@@ -238,7 +251,7 @@ async def test_a_saturated_candidate_list_is_flagged_as_truncated(store, db):
     await db.commit()
 
     with pytest.raises(SupersedeUnresolved) as exc:
-        await store._mark_superseded(OLD[:8], NEW, "2026-09-06T19:53:21+00:00")
+        await _supersede(store, OLD[:8], NEW, "2026-09-06T19:53:21+00:00")
 
     assert exc.value.reason == "ambiguous"
     assert exc.value.truncated is True

--- a/tests/test_memory/test_supersession.py
+++ b/tests/test_memory/test_supersession.py
@@ -180,12 +180,25 @@ async def test_store_with_supersedes_skips_qdrant_for_fts5_only(store, db):
         mock_mem.resolve_id = AsyncMock(
             side_effect=lambda _db, mid: ([mid], "passthrough")
         )
+        # The pre-flight confirms a PASSTHROUGH id names a real row before any
+        # write, and _mark_superseded reads the same row for the collection.
+        # Without this the supersede raised in pre-flight and this test passed
+        # vacuously — update_payload was "not called" because nothing ran.
+        mock_mem.get_metadata = AsyncMock(return_value={
+            "memory_id": old_id, "collection": "episodic_memory",
+            "embedding_status": "fts5_only", "deprecated": 0,
+            "superseded_by": None, "superseded_at": None,
+        })
+        mock_mem.mark_superseded = AsyncMock(return_value=True)
         mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
 
         await store.store("new fact", "conversation", supersedes=old_id)
 
     # Qdrant update_payload should NOT be called for fts5_only memories
     mock_update.assert_not_called()
+    # ...and the supersede must actually have RUN, or the assertion above is
+    # vacuous rather than a skip.
+    mock_mem.mark_superseded.assert_awaited_once()
 
 
 @pytest.mark.asyncio()
@@ -248,30 +261,35 @@ async def test_store_without_supersedes_skips_deprecation(store, db):
 
 
 @pytest.mark.asyncio()
-async def test_supersedes_failure_does_not_block_store(store, db):
-    """If supersession fails, the new memory should still be stored successfully."""
+async def test_an_infrastructure_failure_during_supersede_does_not_block_the_store(
+    store, db
+):
+    """A deprecation that fails AFTER pre-flight must not lose the new memory.
+
+    The target was resolved and confirmed to exist before any write, so a
+    failure here is an infrastructure fault (a locked DB, a dead connection),
+    not a bad handle. The content is already durable at that point, and turning
+    it into a raised error reads as "the store failed" and invites a retry that
+    duplicates the memory.
+    """
     old_id = "nonexistent-id"
-
-    # Make the metadata lookup fail
-    async def failing_execute(sql, params=None):
-        if isinstance(sql, str) and "deprecated = 1" in sql:
-            raise RuntimeError("simulated DB error")
-        cursor = AsyncMock()
-        cursor.fetchone = AsyncMock(return_value=None)
-        return cursor
-
-    db.execute = AsyncMock(side_effect=failing_execute)
 
     with patch("genesis.memory.store.upsert_point"), \
          patch("genesis.memory.store.memory_crud") as mock_mem:
         mock_mem.upsert = AsyncMock(return_value="id")
         mock_mem.create_metadata = AsyncMock(return_value=None)
-        # _mark_superseded now resolves short handles before the UPDATE (see
-        # test_supersede_prefix_resolution). These ids are non-hex, so the real
-        # resolver returns them PASSTHROUGH untouched with no DB read — mirror
-        # that exactly rather than inventing a verdict the resolver never gives.
         mock_mem.resolve_id = AsyncMock(
             side_effect=lambda _db, mid: ([mid], "passthrough")
+        )
+        # Pre-flight PASSES — the row exists...
+        mock_mem.get_metadata = AsyncMock(return_value={
+            "memory_id": old_id, "collection": "episodic_memory",
+            "embedding_status": "fts5_only", "deprecated": 0,
+            "superseded_by": None, "superseded_at": None,
+        })
+        # ...and the deprecation itself then fails on infrastructure.
+        mock_mem.mark_superseded = AsyncMock(
+            side_effect=RuntimeError("simulated DB error")
         )
         mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
 
@@ -284,6 +302,61 @@ async def test_supersedes_failure_does_not_block_store(store, db):
     # Store should succeed despite supersession failure
     assert isinstance(result, str)
     assert len(result) == 36
+    mock_mem.mark_superseded.assert_awaited_once(), "the failure must be the real one"
+
+
+@pytest.mark.asyncio()
+@pytest.mark.parametrize(
+    ("handle", "resolver_verdict"),
+    [
+        ("deadbeef", ([], "not_found")),
+        (
+            "deadbeef-0000-4000-8000-000000000009",
+            (["deadbeef-0000-4000-8000-000000000009"], "passthrough"),
+        ),
+    ],
+    ids=["prefix-matches-nothing", "full-id-names-nothing"],
+)
+async def test_an_unresolvable_target_is_rejected_before_anything_is_written(
+    store, db, handle, resolver_verdict
+):
+    """The hoist, locked: pre-flight runs BEFORE the first write.
+
+    Two things depend on this ordering, and neither is provable from
+    `_mark_superseded` alone:
+
+    * Nothing durable exists when the rejection happens, so it can be a plain
+      raise instead of a half-completed operation the caller has to reason
+      about.
+    * Resolution cannot see the row this very call is about to write. When it
+      ran afterwards, a short prefix could match the NEW memory and deprecate
+      it as its own successor.
+
+    Both resolver verdicts are covered. They fail in DIFFERENT places — a
+    prefix is rejected by the resolver, while a full-length id is waved through
+    as PASSTHROUGH and is only known to be bad once its row is looked up — so
+    one case passing says nothing about the other.
+    """
+    from genesis.memory.store import SupersedeUnresolved
+
+    with patch("genesis.memory.store.upsert_point") as mock_upsert, \
+         patch("genesis.memory.store.memory_crud") as mock_mem:
+        mock_mem.upsert = AsyncMock(return_value="id")
+        mock_mem.create_metadata = AsyncMock(return_value=None)
+        mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
+        mock_mem.resolve_id = AsyncMock(return_value=resolver_verdict)
+        # A full-length id passes resolution untouched; only this lookup can
+        # tell that it names nothing.
+        mock_mem.get_metadata = AsyncMock(return_value=None)
+        mock_mem.mark_superseded = AsyncMock(return_value=True)
+
+        with pytest.raises(SupersedeUnresolved) as exc:
+            await store.store("a correction", "conversation", supersedes=handle)
+
+    assert exc.value.reason == "not_found"
+    mock_mem.create_metadata.assert_not_awaited(), "wrote the memory before checking"
+    mock_upsert.assert_not_called()
+    mock_mem.mark_superseded.assert_not_awaited()
 
 
 @pytest.mark.asyncio()

--- a/tests/test_memory/test_supersession.py
+++ b/tests/test_memory/test_supersession.py
@@ -77,6 +77,13 @@ async def test_store_with_supersedes_marks_old_deprecated(store, db):
          patch("genesis.memory.store.memory_links_crud") as mock_links:
         mock_mem.upsert = AsyncMock(return_value="id")
         mock_mem.create_metadata = AsyncMock(return_value=None)
+        # _mark_superseded now resolves short handles before the UPDATE (see
+        # test_supersede_prefix_resolution). These ids are non-hex, so the real
+        # resolver returns them PASSTHROUGH untouched with no DB read — mirror
+        # that exactly rather than inventing a verdict the resolver never gives.
+        mock_mem.resolve_id = AsyncMock(
+            side_effect=lambda _db, mid: ([mid], "passthrough")
+        )
         mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
         mock_mem.mark_superseded = AsyncMock(return_value=True)
         mock_mem.get_metadata = AsyncMock(return_value={
@@ -113,6 +120,13 @@ async def test_store_with_supersedes_updates_qdrant(store, db):
          patch("genesis.memory.store.memory_links_crud") as mock_links:
         mock_mem.upsert = AsyncMock(return_value="id")
         mock_mem.create_metadata = AsyncMock(return_value=None)
+        # _mark_superseded now resolves short handles before the UPDATE (see
+        # test_supersede_prefix_resolution). These ids are non-hex, so the real
+        # resolver returns them PASSTHROUGH untouched with no DB read — mirror
+        # that exactly rather than inventing a verdict the resolver never gives.
+        mock_mem.resolve_id = AsyncMock(
+            side_effect=lambda _db, mid: ([mid], "passthrough")
+        )
         mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
         mock_mem.mark_superseded = AsyncMock(return_value=True)
         mock_mem.get_metadata = AsyncMock(return_value={
@@ -159,6 +173,13 @@ async def test_store_with_supersedes_skips_qdrant_for_fts5_only(store, db):
          patch("genesis.memory.store.memory_crud") as mock_mem:
         mock_mem.upsert = AsyncMock(return_value="id")
         mock_mem.create_metadata = AsyncMock(return_value=None)
+        # _mark_superseded now resolves short handles before the UPDATE (see
+        # test_supersede_prefix_resolution). These ids are non-hex, so the real
+        # resolver returns them PASSTHROUGH untouched with no DB read — mirror
+        # that exactly rather than inventing a verdict the resolver never gives.
+        mock_mem.resolve_id = AsyncMock(
+            side_effect=lambda _db, mid: ([mid], "passthrough")
+        )
         mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
 
         await store.store("new fact", "conversation", supersedes=old_id)
@@ -178,6 +199,13 @@ async def test_store_with_supersedes_creates_succeeded_by_link(store, db):
          patch("genesis.memory.store.memory_links_crud") as mock_links:
         mock_mem.upsert = AsyncMock(return_value="id")
         mock_mem.create_metadata = AsyncMock(return_value=None)
+        # _mark_superseded now resolves short handles before the UPDATE (see
+        # test_supersede_prefix_resolution). These ids are non-hex, so the real
+        # resolver returns them PASSTHROUGH untouched with no DB read — mirror
+        # that exactly rather than inventing a verdict the resolver never gives.
+        mock_mem.resolve_id = AsyncMock(
+            side_effect=lambda _db, mid: ([mid], "passthrough")
+        )
         mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
         mock_mem.mark_superseded = AsyncMock(return_value=True)
         mock_mem.get_metadata = AsyncMock(return_value={
@@ -205,6 +233,13 @@ async def test_store_without_supersedes_skips_deprecation(store, db):
          patch("genesis.memory.store.memory_crud") as mock_mem:
         mock_mem.upsert = AsyncMock(return_value="id")
         mock_mem.create_metadata = AsyncMock(return_value=None)
+        # _mark_superseded now resolves short handles before the UPDATE (see
+        # test_supersede_prefix_resolution). These ids are non-hex, so the real
+        # resolver returns them PASSTHROUGH untouched with no DB read — mirror
+        # that exactly rather than inventing a verdict the resolver never gives.
+        mock_mem.resolve_id = AsyncMock(
+            side_effect=lambda _db, mid: ([mid], "passthrough")
+        )
         mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
 
         await store.store("normal content", "conversation")
@@ -231,6 +266,13 @@ async def test_supersedes_failure_does_not_block_store(store, db):
          patch("genesis.memory.store.memory_crud") as mock_mem:
         mock_mem.upsert = AsyncMock(return_value="id")
         mock_mem.create_metadata = AsyncMock(return_value=None)
+        # _mark_superseded now resolves short handles before the UPDATE (see
+        # test_supersede_prefix_resolution). These ids are non-hex, so the real
+        # resolver returns them PASSTHROUGH untouched with no DB read — mirror
+        # that exactly rather than inventing a verdict the resolver never gives.
+        mock_mem.resolve_id = AsyncMock(
+            side_effect=lambda _db, mid: ([mid], "passthrough")
+        )
         mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
 
         result = await store.store(
@@ -347,6 +389,13 @@ async def test_supersede_skips_qdrant_for_non_embedded(store, status):
          patch("genesis.memory.store.memory_crud") as mock_mem, \
          patch("genesis.memory.store.memory_links_crud") as mock_links:
         mock_mem.mark_superseded = AsyncMock(return_value=True)
+        # _mark_superseded now resolves short handles before the UPDATE (see
+        # test_supersede_prefix_resolution). These ids are non-hex, so the real
+        # resolver returns them PASSTHROUGH untouched with no DB read — mirror
+        # that exactly rather than inventing a verdict the resolver never gives.
+        mock_mem.resolve_id = AsyncMock(
+            side_effect=lambda _db, mid: ([mid], "passthrough")
+        )
         mock_mem.get_metadata = AsyncMock(return_value={
             "memory_id": "old", "collection": "episodic_memory",
             "embedding_status": status, "deprecated": 0,
@@ -379,6 +428,13 @@ async def test_supersede_link_invalidates_the_graph_cache(store, db):
                side_effect=lambda: calls.append(1)):
         mock_mem.upsert = AsyncMock(return_value="id")
         mock_mem.create_metadata = AsyncMock(return_value=None)
+        # _mark_superseded now resolves short handles before the UPDATE (see
+        # test_supersede_prefix_resolution). These ids are non-hex, so the real
+        # resolver returns them PASSTHROUGH untouched with no DB read — mirror
+        # that exactly rather than inventing a verdict the resolver never gives.
+        mock_mem.resolve_id = AsyncMock(
+            side_effect=lambda _db, mid: ([mid], "passthrough")
+        )
         mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
         mock_mem.mark_superseded = AsyncMock(return_value=True)
         mock_mem.get_metadata = AsyncMock(return_value={
@@ -408,6 +464,13 @@ async def test_failed_supersede_link_does_not_invalidate(store, db):
                side_effect=lambda: calls.append(1)):
         mock_mem.upsert = AsyncMock(return_value="id")
         mock_mem.create_metadata = AsyncMock(return_value=None)
+        # _mark_superseded now resolves short handles before the UPDATE (see
+        # test_supersede_prefix_resolution). These ids are non-hex, so the real
+        # resolver returns them PASSTHROUGH untouched with no DB read — mirror
+        # that exactly rather than inventing a verdict the resolver never gives.
+        mock_mem.resolve_id = AsyncMock(
+            side_effect=lambda _db, mid: ([mid], "passthrough")
+        )
         mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
         mock_mem.mark_superseded = AsyncMock(return_value=True)
         mock_mem.get_metadata = AsyncMock(return_value={


### PR DESCRIPTION
**Split 1 of 5 from #1831.** Base: `main`. Nothing depends on this except the
rest of the split.

## Why this is split at all

#1831 grew across two review rounds while its findings *rose*:

```
insertions:  731 -> 827 -> 1193 -> 1372
findings:    round 1 = 2,   round 2 = 4
```

Round 2's findings were entirely about round 1's own additions — the
whack-a-mole signature. Measured on this repo the same day: **86% of PRs over
1,000 lines reach 3+ Codex rounds, against 6% of PRs under 200.** Size is the
mechanism, so the split is the fix. Nothing is being dropped; every finding is
carried into whichever PR owns the concern it belongs to.

## The defect this PR fixes

`memory_store` accepts a `supersedes` id. The proactive recall hook prints
memories as short `id:<8-char>` handles, and the READ path resolves them —
`memory_expand`'s `_resolve_id_prefixes` docstring says the handles "must
resolve here". The WRITE path never did.

So a short handle went into an exact-match `UPDATE`, matched nothing, and
`mark_superseded`'s `rowcount > 0` return — which exists to report exactly that
— was discarded. `get_metadata` then returned `None`, skipping the vector
payload update. `memory_links.create` has no foreign key, so the only artifact
of the entire operation was a `succeeded_by` edge whose source was not a memory.

The call returned a memory id. The caller read success. The memory that should
have been deprecated stayed live in recall.

## Measured

On one install, before the fix:

| | |
|---|---|
| dangling `succeeded_by` edges (source has no metadata row) | **3** |
| when | a 14-minute window, same day |
| ever before | **0**, out of 264,908 links |
| each handle resolved to | exactly one memory — **resolution alone would have prevented all three** |

Two of the three were retried with the full id about ninety seconds later, so
the silence also duplicated the correction. The third was never retried: it sat
`deprecated=0` with its own correction unlinked.

One measurement is worth recording as a *non*-finding: 1,095 of 1,146
`succeeded_by` links have a non-deprecated source, which looks alarming and is
not. `succeeded_by` has a second producer — the relationship classifier emits it
as a semantic "B updates A" link that deliberately deprecates nothing. Only a
source with no metadata row at all is unambiguous.

## The change

- **`crud/memory.py`** — `resolve_id()`, a wrapper over the existing shared
  `_id_resolve.resolve_unique_prefix`. `full_len=36` because memory ids are
  dashed uuid4. Note the mechanism, since the obvious reading is wrong: a
  complete 36-char id is passthrough under either value; what `36` changes is
  the **32-to-35 band** — a truncated paste, which the default would wave
  through as full-length into an exact match that cannot hit.
- **`memory/store.py`** — `_mark_superseded` resolves first, never guesses an
  ambiguous handle, and reads `mark_superseded`'s return so a passthrough id
  naming nothing raises instead of no-opping. Every rejection happens **before
  any write**, so an unresolvable supersede can no longer leave a dangling edge
  behind.

## What is deliberately NOT here

Each is its own PR in this split, listed so the omission reads as a decision:

| concern | PR |
|---|---|
| the dedup short-circuit does not supersede (pre-existing on `main`, unchanged here) | 2 |
| `memory_store` still returns a bare id — `SupersedeUnresolved` is caught by the **existing** handler in `store()` and logged | 3 |
| partial / outright-failed supersede reporting | 4 |
| alias normalization running after the dedup lookup (independent, off `main`) | 5 |

Because of the third row, **this PR changes no tool contract at all**:
`memory_store` still returns `str`, and an unresolvable id now produces a
warning log with a traceback where `main` produced nothing.

## Verification

- **Verify-RED, two mutations, both applied and both biting.** The mutation
  script aborts if its anchor text is absent, so a green run cannot be a
  silently-unapplied mutation.
  - delete the resolve block (restore `main`'s exact-match behaviour) → 5 failed
  - discard `mark_superseded`'s return → 1 failed
    (`test_a_full_id_naming_no_memory_is_reported_not_swallowed`). This is the
    mutation #1831 recorded as a **survivor** before it had that test; re-derived
    here rather than inherited.
- 114 targeted tests green (`test_supersession`, `test_supersede_prefix_resolution`,
  `test_mcp_integration`, `test_memory_mcp`); `ruff` clean.
- Real SQLite in the new test file, not mocks — the defect IS which rows the SQL
  matches, and a mocked connection would confirm whatever the test asserted. The
  fixture DDL is copied from production `sqlite_master`: #1831's first RED run was
  **rejected as invalid** because a hand-rolled fixture omitted a column, so the
  lock failed for a fixture reason rather than the real one.
- The nine `resolve_id` mocks added to `test_supersession.py` mirror the real
  resolver's verdict (non-hex → passthrough, no DB read). Seven of those tests
  were red without them; **three more would have kept passing for the wrong
  reason**, because their assertions are all negative and `store()`'s broad
  handler swallows the `TypeError`. That is why the mock was added uniformly
  rather than only where the suite was red.

The wider class — id-taking tools that exact-match the short handles the system
itself hands out — is tracked in #1827.

E2E: `memory_store(supersedes=<8-char handle>)` via MCP and `POST /api/t/memory_store` — confirm the target's `deprecated` flips to 1 with `superseded_by` set, and that a bogus full-length id leaves no `succeeded_by` row behind (it previously wrote one from a non-memory source).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resolving memories by full ID or shortened ID handle.
  * Supersession now reports clear errors when an ID is missing, ambiguous, or cannot be resolved.

* **Bug Fixes**
  * Prevented supersession links from being created when the target memory cannot be uniquely identified.
  * Improved handling of truncated memory IDs while preserving existing full-ID behavior.

* **Tests**
  * Added coverage for unique, ambiguous, missing, and truncated memory ID resolution during supersession.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->