### PR TITLE
fix(memory): report the supersede outcome to the caller, not to the log

### DIFF
--- a/changelog.d/20260910191000-fixed-supersede-reports-its-outcome.md
+++ b/changelog.d/20260910191000-fixed-supersede-reports-its-outcome.md
@@ -1,0 +1,19 @@
+- **A supersede that could not be performed now says so to the caller.** Until
+  now `memory_store` returned a memory id whether or not the deprecation it was
+  asked for had happened: a failure was written to the server log and nothing
+  else, so a session was told its correction had landed while the stale memory
+  stayed live in recall.
+
+  When `supersedes` is passed, the call now returns a report -- whether the
+  deprecation happened, which id did land, why it did not, and which ids
+  collided for an ambiguous handle. Without `supersedes` the return is the
+  memory id string exactly as before, so the overwhelming majority of calls are
+  unchanged.
+
+  It reports rather than raises on purpose: the memory is durable by that
+  point, and an exception reads as "the store failed" and invites the retry
+  that duplicates the memory. The advice fits the reason -- "re-send with a
+  full 36-character id" is the fix for a handle that named nothing, and the
+  wrong instruction for a correction that collided with its own target, where
+  re-sending reproduces the collision. An empty or all-whitespace `supersedes`
+  is treated as no request at all rather than as a supersede that succeeded.

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -824,8 +824,20 @@ async def memory_store(
     room: str | None = None,
     collection: str | None = None,
     supersedes: str | None = None,
-) -> str:
+) -> str | dict:
     """Store memory with source metadata and type tag. Returns memory_id.
+
+    Return shape depends on ``supersedes``, which the caller controls: without
+    it you get the memory_id string, exactly as before. WITH it you get a dict
+    ``{"memory_id", "superseded", ...}`` reporting whether the deprecation
+    actually happened — because it can fail on its own while the store
+    succeeds, and reporting only the id is what let that failure go unnoticed.
+    ``reason`` names why a supersede did not happen, and the ``warning`` gives
+    advice that fits that reason.
+
+    This tool is also reachable over HTTP as ``POST /api/t/memory_store``
+    (``dashboard/routes/tool_api.py``), which accepts ``supersedes`` like any
+    other parameter — so the conditional shape is visible to that door too.
 
     Args:
         memory_class: Optional classification — "rule", "fact", or "reference".
@@ -836,7 +848,13 @@ async def memory_store(
             collection routing when provided (e.g. "knowledge_base").
         supersedes: Memory ID that this new memory replaces. The old memory
             will be marked as deprecated with a ``succeeded_by`` link to the
-            new one. Use when correcting stale facts.
+            new one. Use when correcting stale facts. Accepts the same short
+            ``id:<8-char>`` handles the proactive hook prints and
+            ``memory_expand`` accepts; an ambiguous handle is never guessed.
+            When the supersede cannot be performed the memory is STILL STORED
+            and the returned dict says so — do not retry the store blindly, or
+            you will duplicate the memory (measured: that retry happened twice
+            on 2026-09-06 while this path was silent).
     """
     memory_mod = _memory_mod()
     memory_mod._require_init()
@@ -847,21 +865,89 @@ async def memory_store(
     # external-influenced session's writes stop landing first_party via the
     # "conversation" pipeline. None (foreground/unset) → pipeline-derived.
     from genesis.memory.provenance import session_origin_from_env
+    from genesis.memory.store import SupersedeUnresolved
 
-    return await memory_mod._store.store(
-        content,
-        source,
-        memory_type=memory_type,
-        tags=tags,
-        confidence=confidence,
-        memory_class=memory_class,
-        source_pipeline="conversation",
-        origin_class=session_origin_from_env(),
-        wing=wing,
-        room=room,
-        collection=collection,
-        supersedes=supersedes,
-    )
+    # An empty or all-whitespace handle is not a request. Both store-side
+    # guards are truthiness tests (`if supersedes:`), so "" and "   " perform no
+    # deprecation at all — while an `is None` test here would treat them as a
+    # requested supersede and build a success report about an operation that
+    # never ran. Normalized ONCE, so the two layers cannot disagree about what
+    # counts as a request. MCP and `POST /api/t/memory_store` both accept a
+    # string, so an empty one arrives without any client bug.
+    supersedes = supersedes.strip() if supersedes else None
+
+    try:
+        memory_id = await memory_mod._store.store(
+            content,
+            source,
+            memory_type=memory_type,
+            tags=tags,
+            confidence=confidence,
+            memory_class=memory_class,
+            source_pipeline="conversation",
+            origin_class=session_origin_from_env(),
+            wing=wing,
+            room=room,
+            collection=collection,
+            supersedes=supersedes,
+        )
+    except SupersedeUnresolved as exc:
+        # The memory IS durable; only the deprecation failed. Report both
+        # halves rather than raising — an exception here reads as "the store
+        # failed" and invites the retry that duplicates the memory.
+        #
+        # The advice is REASON-SPECIFIC. "Re-send with a full 36-char id" is
+        # the fix for a handle that named nothing or named several; it is the
+        # wrong instruction for the two successor-validation reasons, where the
+        # target id was fine and re-sending the same content reproduces the
+        # same collision. Handing a caller an instruction that cannot work is
+        # how the original defect kept its retry loop going.
+        if exc.reason == "self_supersede":
+            advice = (
+                "The content you sent is byte-identical to the memory you asked "
+                "to supersede, so the correction and its target are the SAME "
+                "memory, and a memory cannot replace itself. Nothing was "
+                "deprecated. Send the CORRECTED content, or name the memory you "
+                "actually meant to deprecate."
+            )
+        elif exc.reason == "successor_deprecated":
+            advice = (
+                f"The content you sent already exists as memory "
+                f"{exc.stored_memory_id}, which is itself DEPRECATED and so is "
+                "filtered out of normal recall — it cannot carry the correction. "
+                "Nothing was deprecated. Send the correction as new content."
+            )
+        else:
+            advice = (
+                "Re-run memory_store with the SAME content and a full 36-char "
+                "memory id: the content will not be duplicated, and the "
+                "supersede will be applied to the memory that already landed. "
+                "There is no standalone supersede tool."
+            )
+        return {
+            "memory_id": exc.stored_memory_id,
+            "superseded": False,
+            "supersedes_requested": supersedes,
+            "reason": exc.reason,
+            "candidates": exc.candidates,
+            "candidates_truncated": exc.truncated,
+            "warning": (
+                f"The memory WAS stored ({exc.stored_memory_id}). The supersede "
+                f"did NOT happen: {supersedes!r} is {exc.reason}. The old memory "
+                f"is still live in recall. {advice}"
+            ),
+        }
+
+    # Normalized ABOVE, so the store and this report agree on what "asked for a
+    # supersede" means — see the note there.
+    if not supersedes:
+        return memory_id
+
+    return {
+        "memory_id": memory_id,
+        "superseded": True,
+        "supersedes_requested": supersedes,
+    }
 
 
 @mcp.tool()

--- a/src/genesis/memory/store.py
+++ b/src/genesis/memory/store.py
@@ -256,6 +256,12 @@ class MemoryStore:
                         supersedes, existing, datetime.now(UTC).isoformat(),
                         verify_successor=True,
                     )
+                except SupersedeUnresolved:
+                    # Escapes to the reporting layer exactly as it does on the
+                    # normal path below. The `existing` id it carries is the
+                    # memory that already held this content, so the caller is
+                    # never left without a handle on what is durable.
+                    raise
                 except Exception:
                     # Mirrors the normal supersede path below: a failed
                     # deprecation must not turn a durable store into a raised
@@ -575,6 +581,13 @@ class MemoryStore:
         if supersedes:
             try:
                 await self._mark_superseded(supersedes, memory_id, now_iso)
+            except SupersedeUnresolved:
+                # Deliberately NOT swallowed. The memory above is already
+                # durable, so this is a partial outcome the caller must see —
+                # swallowing it is what let a session be told its correction
+                # landed while the stale memory stayed live in recall. Carries
+                # memory_id so the MCP layer can report both halves.
+                raise
             except Exception:
                 logger.warning(
                     "Failed to mark memory %s as superseded by %s",

--- a/tests/test_mcp/test_memory_mcp.py
+++ b/tests/test_mcp/test_memory_mcp.py
@@ -2237,3 +2237,146 @@ async def test_memory_recall_wing_validation_shares_one_definition_with_the_writ
             mod.side_effect = RuntimeError("reached the search path")
             with pytest.raises(RuntimeError):
                 await tools["memory_recall"].fn(query="q", wing=wing)
+
+
+# --- memory_store: a supersede that fails must not read as a clean store -----
+# MEASURED 2026-09-06: three `succeeded_by` edges whose source was an 8-char
+# handle, created in a 14-minute window (0 historically). The store returned an
+# id, the caller read success, and one target is still deprecated=0 — a memory a
+# session believed it had corrected, still live in recall. Two of the three were
+# RETRIED ~90s later with the full id, so the silence also duplicated memories.
+
+
+@pytest.mark.asyncio
+async def test_memory_store_without_supersedes_still_returns_a_bare_id():
+    """Contract lock: the ~all-calls path is untouched by the report shape."""
+    from genesis.mcp.memory import core
+
+    tools = await _get_tools()
+    with patch.object(core, "_memory_mod") as mod:
+        mod.return_value._store = MagicMock()
+        mod.return_value._store.store = AsyncMock(return_value="mem-id")
+        result = await tools["memory_store"].fn("content", "src")
+
+    assert result == "mem-id"
+    assert isinstance(result, str)
+
+
+@pytest.mark.asyncio
+async def test_memory_store_reports_a_successful_supersede():
+    """Asking for a supersede gets you a verdict, not just an id."""
+    from genesis.mcp.memory import core
+
+    tools = await _get_tools()
+    with patch.object(core, "_memory_mod") as mod:
+        mod.return_value._store = MagicMock()
+        mod.return_value._store.store = AsyncMock(return_value="new-id")
+        result = await tools["memory_store"].fn("content", "src", supersedes="old-id")
+
+    assert result["memory_id"] == "new-id"
+    assert result["superseded"] is True
+
+
+@pytest.mark.asyncio
+async def test_memory_store_reports_an_unresolved_supersede_without_losing_the_memory():
+    """The stored id survives, the failure is stated, and retry is warned off."""
+    from genesis.mcp.memory import core
+    from genesis.memory.store import SupersedeUnresolved
+
+    tools = await _get_tools()
+    with patch.object(core, "_memory_mod") as mod:
+        mod.return_value._store = MagicMock()
+        mod.return_value._store.store = AsyncMock(
+            side_effect=SupersedeUnresolved("abcd1234", "not_found", "new-id")
+        )
+        result = await tools["memory_store"].fn(
+            "content", "src", supersedes="abcd1234"
+        )
+
+    # The content is NOT lost — that is why this reports instead of raising.
+    assert result["memory_id"] == "new-id"
+    assert result["superseded"] is False
+    assert result["reason"] == "not_found"
+    # And it must give an instruction that is actually executable: there is no
+    # standalone supersede tool, so "re-issue the supersede" was uncompletable.
+    # The retry is safe because the dedup path supersedes too.
+    assert "WAS stored" in result["warning"]
+    assert "same content" in result["warning"].lower()
+    assert "will not be duplicated" in result["warning"]
+
+
+@pytest.mark.asyncio
+async def test_memory_store_names_the_candidates_of_an_ambiguous_supersede():
+    """An ambiguous handle is never guessed; the caller is told which ids collide."""
+    from genesis.mcp.memory import core
+    from genesis.memory.store import SupersedeUnresolved
+
+    tools = await _get_tools()
+    with patch.object(core, "_memory_mod") as mod:
+        mod.return_value._store = MagicMock()
+        mod.return_value._store.store = AsyncMock(
+            side_effect=SupersedeUnresolved(
+                "abcd1234", "ambiguous", "new-id", ["abcd1234-aaa", "abcd1234-bbb"]
+            )
+        )
+        result = await tools["memory_store"].fn(
+            "content", "src", supersedes="abcd1234"
+        )
+
+    assert result["superseded"] is False
+    assert result["reason"] == "ambiguous"
+    assert result["candidates"] == ["abcd1234-aaa", "abcd1234-bbb"]
+
+
+@pytest.mark.asyncio()
+async def test_memory_store_advice_fits_the_reason_it_reports():
+    """"Re-send with a full 36-char id" is the fix for a handle that named
+    nothing. For the successor-validation reasons the target id was FINE and
+    re-sending the same content reproduces the same collision, so that
+    instruction cannot work — and an uncompletable instruction is what kept the
+    original defect's retry loop running.
+    """
+    from genesis.mcp.memory import core
+    from genesis.memory.store import SupersedeUnresolved
+
+    tools = await _get_tools()
+    with patch.object(core, "_memory_mod") as mod:
+        mod.return_value._store = MagicMock()
+        mod.return_value._store.store = AsyncMock(
+            side_effect=SupersedeUnresolved("abcd1234", "self_supersede", "abcd1234-x")
+        )
+        result = await tools["memory_store"].fn(
+            "content", "src", supersedes="abcd1234"
+        )
+
+    assert result["superseded"] is False
+    assert result["reason"] == "self_supersede"
+    assert "cannot replace itself" in result["warning"]
+    assert "36-char" not in result["warning"], (
+        "handed back the not_found advice, which cannot resolve a self-supersede"
+    )
+
+
+@pytest.mark.asyncio()
+async def test_memory_store_does_not_report_a_supersede_nobody_asked_for():
+    """An empty `supersedes` must not produce `superseded: True`.
+
+    Both store-side guards are truthiness tests (`if supersedes:`), so "" and
+    "   " perform no deprecation at all. An `is None` test here would treat
+    them as a requested supersede and build a success report about an operation
+    that never ran. MCP and `POST /api/t/memory_store` both take a string here,
+    so an empty one arrives without any client bug.
+    """
+    from genesis.mcp.memory import core
+
+    tools = await _get_tools()
+    for empty in ("", "   "):
+        with patch.object(core, "_memory_mod") as mod:
+            mod.return_value._store = MagicMock()
+            mod.return_value._store.store = AsyncMock(return_value="new-id")
+            result = await tools["memory_store"].fn("content", "src", supersedes=empty)
+
+        assert result == "new-id", (
+            f"supersedes={empty!r} produced a supersede report: {result!r}"
+        )
+        assert isinstance(result, str), "the bare-id shape is what a non-request returns"

--- a/tests/test_memory/test_supersede_prefix_resolution.py
+++ b/tests/test_memory/test_supersede_prefix_resolution.py
@@ -306,14 +306,18 @@ async def test_dedup_short_circuit_cannot_self_supersede(store, db):
     content it has not actually changed, which is the shape a retried
     correction takes.
 
-    ``store()`` swallows the rejection and returns the surviving id, exactly as
-    the normal supersede path does; what must hold is that NOTHING was mutated.
+    The rejection escapes ``store()`` so the reporting layer can tell the
+    caller; what must also hold is that NOTHING was mutated.
     """
+    from genesis.memory.store import SupersedeUnresolved
+
     await _index(db, OLD, DUPE)
 
-    returned = await store.store(DUPE, "conversation", supersedes=PREFIX)
+    with pytest.raises(SupersedeUnresolved) as exc:
+        await store.store(DUPE, "conversation", supersedes=PREFIX)
 
-    assert returned == OLD, "the caller needs the surviving id"
+    assert exc.value.reason == "self_supersede"
+    assert exc.value.stored_memory_id == OLD, "the caller needs the surviving id"
     assert (await _row(db, OLD))["deprecated"] == 0
     assert await _links(db) == []
 
@@ -326,11 +330,14 @@ async def test_a_deprecated_dedup_candidate_cannot_carry_the_correction(store, d
     recall, so the correction is unreachable — and nothing raised out of
     ``_mark_superseded``, so it looked like a completed supersede.
     """
+    from genesis.memory.store import SupersedeUnresolved
+
     await _index(db, DEAD, DUPE)
 
-    returned = await store.store(DUPE, "conversation", supersedes=OLD)
+    with pytest.raises(SupersedeUnresolved) as exc:
+        await store.store(DUPE, "conversation", supersedes=OLD)
 
-    assert returned == DEAD
+    assert exc.value.reason == "successor_deprecated"
     assert (await _row(db, OLD))["deprecated"] == 0, (
         "deprecated the target toward a successor recall cannot see"
     )

--- a/tests/test_memory/test_supersession.py
+++ b/tests/test_memory/test_supersession.py
@@ -521,7 +521,7 @@ async def test_dedup_short_circuit_still_supersedes(store, db):
 
 
 @pytest.mark.asyncio()
-async def test_dedup_path_supersede_failure_does_not_duplicate(store, db):
+async def test_dedup_path_unresolved_supersede_does_not_duplicate(store, db):
     """A supersede failure on the dedup path must not reach the store pipeline.
 
     Found in review of PR #1831. The supersede call added to the dedup path sat
@@ -532,8 +532,12 @@ async def test_dedup_path_supersede_failure_does_not_duplicate(store, db):
     lookup had proved already existed.
 
     ``create_metadata.assert_not_awaited()`` is the duplication itself, not a
-    proxy for it.
+    proxy for it. ``stored_memory_id`` is an independent assertion: it proves
+    the error names the memory that already existed rather than a freshly
+    minted duplicate id.
     """
+    from genesis.memory.store import SupersedeUnresolved
+
     with patch("genesis.memory.store.upsert_point"), \
          patch("genesis.memory.store.update_payload"), \
          patch("genesis.memory.store.memory_crud") as mock_mem, \
@@ -547,10 +551,52 @@ async def test_dedup_path_supersede_failure_does_not_duplicate(store, db):
         mock_mem.mark_superseded = AsyncMock(return_value=True)
         mock_links.create = AsyncMock(return_value=("old", "new"))
 
-        out = await store.store(
-            "a correction", "conversation", supersedes="deadbeef",
-        )
+        with pytest.raises(SupersedeUnresolved) as exc:
+            await store.store(
+                "a correction", "conversation", supersedes="deadbeef",
+            )
 
     mock_mem.create_metadata.assert_not_awaited()
-    assert out == "pre-existing-id", "the surviving memory must be returned"
+    assert exc.value.stored_memory_id == "pre-existing-id", (
+        "the error must name the memory that already exists, not a duplicate "
+        "the full pipeline minted after the exception was swallowed"
+    )
+    assert exc.value.reason == "not_found"
+    mock_mem.mark_superseded.assert_not_awaited()
+
+
+@pytest.mark.asyncio()
+async def test_store_lets_an_unresolved_supersede_out(store, db):
+    """store() must NOT swallow SupersedeUnresolved on the normal path either.
+
+    Added because a mutation survived: re-widening the call site's
+    ``except Exception`` to catch this error broke nothing, since every other
+    test either calls ``_mark_superseded`` directly or mocks ``store`` whole.
+    That except clause IS the live defect (a session was told its correction
+    landed while the stale memory stayed in recall), so it needs a test that
+    reaches it.
+    """
+    from genesis.memory.store import SupersedeUnresolved
+
+    with patch("genesis.memory.store.upsert_point"), \
+         patch("genesis.memory.store.update_payload"), \
+         patch("genesis.memory.store.memory_crud") as mock_mem, \
+         patch("genesis.memory.store.memory_links_crud") as mock_links:
+        mock_mem.upsert = AsyncMock(return_value="id")
+        mock_mem.create_metadata = AsyncMock(return_value=None)
+        mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
+        # The handle names no memory — the resolver's NOT_FOUND verdict.
+        mock_mem.resolve_id = AsyncMock(return_value=([], "not_found"))
+        mock_mem.mark_superseded = AsyncMock(return_value=True)
+        mock_links.create = AsyncMock(return_value=("old", "new"))
+
+        with pytest.raises(SupersedeUnresolved) as exc:
+            await store.store(
+                "a correction", "conversation", supersedes="deadbeef",
+            )
+
+    assert exc.value.reason == "not_found"
+    # The new memory was still written before the supersede was attempted —
+    # that is why the MCP layer reports instead of raising to the caller.
+    assert exc.value.stored_memory_id
     mock_mem.mark_superseded.assert_not_awaited()


### PR DESCRIPTION
**Split 3 of 5 from #1831.** Base: `fix/supersede-dedup-short-circuit` (#1929).

> **Stacked**, two deep: `main` → #1928 → #1929 → this. It needs
> `SupersedeUnresolved` from #1928 and — for its retry advice to be **true** —
> the dedup-path supersede from #1929. **CI does not run for a non-default
> base**; the targeted suites were run locally and are recorded below.

## What this adds

The previous two PRs made the supersede resolve its target and made the dedup
path perform it. Both wrote their failures **to the server log** and returned a
memory id regardless — so the caller still read success while the stale memory
stayed live in recall. This routes the verdict to the caller.

- **`store()` stops swallowing `SupersedeUnresolved`.** Two clauses, one per call
  site, because a single test cannot reach both.
- **`memory_store` returns a report dict** when `supersedes` was passed, and the
  bare id string otherwise — so the ~all-calls path is untouched. The report says
  whether the deprecation happened, which id **did** land, why it did not, and
  which ids collided for an ambiguous handle, including the resolver's LIMIT-3
  truncation flag so three candidates are never presented as the whole collision
  set.
- **It reports rather than raises.** The memory is durable by that point, and an
  exception reads as "the store failed" and invites the duplicating retry that
  was measured twice on 2026-09-06.
- **The advice fits the reason.** "Re-send with a full 36-char id" fixes a handle
  that named nothing; for the two successor reasons the id was fine and re-sending
  reproduces the collision, which is a loop. Handing back an instruction that
  cannot work is how the original defect kept its retry going.
- **An empty or all-whitespace `supersedes` is not a request.** Both store-side
  guards are truthiness tests, so `""` and `"   "` deprecate nothing — while an
  `is None` test here would have built a success report about an operation that
  never ran. Normalized once, before the store call, so the two layers cannot
  disagree. MCP and `POST /api/t/memory_store` both take a string here, so an
  empty one arrives without any client bug.

## Blast radius — enumerated, not spot-checked

- `grep -rn 'supersedes=' src/ --include=*.py` returns exactly **two** lines: the
  parameter's own definition and `mcp/memory/core.py`. So that module is the sole
  caller that can trigger the exception, and it catches it. **No internal path
  sees it.**
- The HTTP door: `tool_api.py::_normalize_result` (read at lines 79-100) returns
  `dict` and `list` unchanged and only wraps scalars, so both shapes serialize
  correctly through `POST /api/t/memory_store`.

## Verification

**Verify-RED — 4 mutations, all applied, all biting.**

| mutation | result |
|---|---|
| delete `except SupersedeUnresolved: raise` on the **normal** path | `test_store_lets_an_unresolved_supersede_out` red |
| delete it on the **dedup** path | 3 red |
| guard reverts to `if supersedes is None` | empty-`supersedes` test red |
| collapse the reason branches to one advice string | advice test red |

The first two fail **disjoint** test sets — that is the point of having two
clauses and two tests. The third bites for a specific reason worth stating:
`""` folds to `None` and would pass either guard, but `"   "` normalizes to `""`,
truthy under `is None` and falsy under `not` — so the test loops over **both**
values, and what it pins is the guard form, not the normalization.

- 127 targeted tests green; `ruff` clean.
- `test_memory_store_without_supersedes_still_returns_a_bare_id` uses an explicit
  `isinstance` check, so a dict cannot satisfy it by comparing equal.

## Known and deferred

`superseded: true` here means "nothing raised". A supersede that half-applies
(SQLite deprecation lands, Qdrant payload write swallowed) or fails outright with
a database error still reports `true`. That is real, and it is the entire subject
of **split 4** — named here rather than left for a reviewer to find.

E2E: `memory_store(supersedes=<bogus id>)` via MCP — confirm the response is a dict with `superseded: false`, the stored `memory_id`, and a reason; and that `memory_store(supersedes="")` still returns a bare id string. Both doors: MCP and `POST /api/t/memory_store`.
