### PR TITLE
fix(memory): a partial or failed supersede must not report as complete

### DIFF
--- a/changelog.d/20260910191500-fixed-partial-supersede-not-reported-complete.md
+++ b/changelog.d/20260910191500-fixed-partial-supersede-not-reported-complete.md
@@ -1,0 +1,17 @@
+- **A supersede that only half-applied was reported as complete.** The two
+  steps after the SQLite deprecation -- the vector payload write and the
+  `succeeded_by` link -- are best-effort and swallow their own errors, so a
+  supersede whose payload write failed left the memory hidden from keyword
+  recall and still live in vector recall while the call reported success. The
+  failed steps are now named in a `partial` list on the report.
+
+  A supersede that failed OUTRIGHT with an unexpected database error was also
+  reported as successful: the error was logged and nothing else, and the
+  success report was unconditional. That case is now distinguished from a
+  partial and reported as not superseded, because the caller's next move
+  depends on whether the old memory is still live.
+
+  The two are kept apart by a boundary at the point of no return. Once the
+  deprecation has committed, recall already excludes the old memory, so a
+  failure after that point is a partial no matter what threw -- it can never be
+  reported as "did not happen at all".

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -833,7 +833,10 @@ async def memory_store(
     actually happened — because it can fail on its own while the store
     succeeds, and reporting only the id is what let that failure go unnoticed.
     ``reason`` names why a supersede did not happen, and the ``warning`` gives
-    advice that fits that reason.
+    advice that fits that reason. A partially-applied supersede adds ``partial``
+    naming the steps that did not land; ``partial`` containing
+    ``supersede_failed`` means it did not land AT ALL (an unexpected database
+    error), and ``superseded`` is False there.
 
     This tool is also reachable over HTTP as ``POST /api/t/memory_store``
     (``dashboard/routes/tool_api.py``), which accepts ``supersedes`` like any
@@ -865,7 +868,14 @@ async def memory_store(
     # external-influenced session's writes stop landing first_party via the
     # "conversation" pipeline. None (foreground/unset) → pipeline-derived.
     from genesis.memory.provenance import session_origin_from_env
-    from genesis.memory.store import SupersedeUnresolved
+    from genesis.memory.store import SUPERSEDE_FAILED, SupersedeUnresolved
+
+    # Collector for steps that failed AFTER the SQLite deprecation landed. The
+    # Qdrant payload write and the link create are best-effort and swallow
+    # their own exceptions, and the vector leg of hybrid recall filters on that
+    # Qdrant payload — so without this a partial supersede would be reported as
+    # a complete one, which is the class of lie this whole change exists to stop.
+    degraded: list[str] = []
 
     # An empty or all-whitespace handle is not a request. Both store-side
     # guards are truthiness tests (`if supersedes:`), so "" and "   " perform no
@@ -890,6 +900,7 @@ async def memory_store(
             room=room,
             collection=collection,
             supersedes=supersedes,
+            supersede_degraded=degraded,
         )
     except SupersedeUnresolved as exc:
         # The memory IS durable; only the deprecation failed. Report both
@@ -943,11 +954,38 @@ async def memory_store(
     if not supersedes:
         return memory_id
 
-    return {
+    report: dict = {
         "memory_id": memory_id,
         "superseded": True,
         "supersedes_requested": supersedes,
     }
+    if degraded:
+        report["partial"] = degraded
+        if SUPERSEDE_FAILED in degraded:
+            # The supersede did not merely half-apply — it threw before or
+            # during the SQLite deprecation, so we do NOT know that anything
+            # landed and must not claim it did. `superseded` flips to False for
+            # the same reason SupersedeUnresolved reports False: the caller's
+            # next decision depends on whether the old memory is still live.
+            report["superseded"] = False
+            report["warning"] = (
+                f"The memory WAS stored ({memory_id}), but the supersede FAILED "
+                "with an unexpected error (see the server log for the "
+                "traceback). The old memory is probably still live in recall. "
+                "Do NOT re-send this as a new memory — re-run memory_store with "
+                "the SAME content and the same supersedes id; the content will "
+                "not be duplicated."
+            )
+        else:
+            # The deprecation landed in SQLite but a later step did not. Say
+            # which, rather than letting "superseded: True" stand for a partial.
+            report["warning"] = (
+                "The SQLite deprecation applied, but these steps did NOT: "
+                + ", ".join(degraded)
+                + ". If 'qdrant_payload' is listed the old memory may still "
+                "surface in vector recall even though FTS now hides it."
+            )
+    return report
 
 
 @mcp.tool()

--- a/src/genesis/memory/store.py
+++ b/src/genesis/memory/store.py
@@ -75,6 +75,18 @@ _COLLECTION_MAP = {
 }
 
 
+# Degradation marker for a supersede that failed OUTRIGHT with an unexpected
+# error (a SQLite fault in resolve_id / mark_superseded / get_metadata), as
+# opposed to the post-deprecation partial failures the other markers name.
+# Without it, both `except Exception` handlers below logged and left the
+# out-param empty, and the MCP layer's unconditional `superseded: True` then
+# told the caller a supersede that provably had not happened had succeeded —
+# the same class of lie, arriving by a different door. MEASURED: a raise from
+# resolve_id left the target at deprecated=0 with degraded=[] and the report
+# saying superseded=True.
+SUPERSEDE_FAILED = "supersede_failed"
+
+
 class SupersedeUnresolved(Exception):
     """A supersede could not be performed on the pair it was given.
 
@@ -183,6 +195,7 @@ class MemoryStore:
         life_domain: str | None = None,
         project_type: str | None = None,
         supersedes: str | None = None,
+        supersede_degraded: list[str] | None = None,  # out-param: see below
         origin_class: str | None = None,
         speech_act: str | None = None,
         speech_act_confidence: float | None = None,
@@ -252,10 +265,12 @@ class MemoryStore:
                     # matched, which consults neither the supersede target nor
                     # the deprecation column. It can therefore be the target
                     # itself, or an already-deprecated row. See _mark_superseded.
-                    await self._mark_superseded(
+                    _deg = await self._mark_superseded(
                         supersedes, existing, datetime.now(UTC).isoformat(),
                         verify_successor=True,
                     )
+                    if supersede_degraded is not None:
+                        supersede_degraded.extend(_deg)
                 except SupersedeUnresolved:
                     # Escapes to the reporting layer exactly as it does on the
                     # normal path below. The `existing` id it carries is the
@@ -266,7 +281,11 @@ class MemoryStore:
                     # Mirrors the normal supersede path below: a failed
                     # deprecation must not turn a durable store into a raised
                     # error, which reads as "the store failed" and invites a
-                    # duplicating retry.
+                    # duplicating retry. It must still be REPORTED, though —
+                    # logging alone left the out-param empty and the MCP layer
+                    # said `superseded: True` about a deprecation that never ran.
+                    if supersede_degraded is not None:
+                        supersede_degraded.append(SUPERSEDE_FAILED)
                     logger.warning(
                         "Failed to mark memory %s as superseded by %s",
                         supersedes, existing, exc_info=True,
@@ -580,7 +599,9 @@ class MemoryStore:
         # Supersession: mark old memory as deprecated, link to this one
         if supersedes:
             try:
-                await self._mark_superseded(supersedes, memory_id, now_iso)
+                _deg = await self._mark_superseded(supersedes, memory_id, now_iso)
+                if supersede_degraded is not None:
+                    supersede_degraded.extend(_deg)
             except SupersedeUnresolved:
                 # Deliberately NOT swallowed. The memory above is already
                 # durable, so this is a partial outcome the caller must see —
@@ -589,6 +610,10 @@ class MemoryStore:
                 # memory_id so the MCP layer can report both halves.
                 raise
             except Exception:
+                # Reported, not just logged — see the twin clause on the dedup
+                # path. An empty out-param here becomes `superseded: True`.
+                if supersede_degraded is not None:
+                    supersede_degraded.append(SUPERSEDE_FAILED)
                 logger.warning(
                     "Failed to mark memory %s as superseded by %s",
                     supersedes, memory_id, exc_info=True,
@@ -603,12 +628,20 @@ class MemoryStore:
         timestamp: str,
         *,
         verify_successor: bool = False,
-    ) -> None:
+    ) -> list[str]:
         """Mark *old_id* as superseded by *new_id* in both SQLite and Qdrant.
 
         Sets ``deprecated=1``, ``superseded_by``, and ``superseded_at`` in
         SQLite.  Sets ``deprecated=True`` and ``merged_into`` in the Qdrant
         payload.  Creates a ``succeeded_by`` link from old to new.
+
+        Returns the names of the steps that FAILED — empty means fully applied.
+        The two steps after the SQLite update are best-effort and swallow their
+        exceptions, so without this the caller could be told the correction
+        landed while a stale vector still answered recall: the vector leg of
+        hybrid search filters on the Qdrant ``deprecated`` payload, not on the
+        SQLite column, so a swallowed payload write leaves the memory hidden
+        from FTS and still visible from Qdrant.
 
         Raises ``SupersedeUnresolved`` — BEFORE any write — when *old_id* names
         no memory or names several. Nothing is mutated on that path, so an
@@ -668,6 +701,43 @@ class MemoryStore:
         if not await memory_crud.mark_superseded(self._db, old_id, new_id, timestamp):
             raise SupersedeUnresolved(old_id, "not_found", new_id)
 
+        # ── PAST THE POINT OF NO RETURN ──────────────────────────────────────
+        # The deprecation is COMMITTED (crud.mark_superseded commits before it
+        # returns), so SQLite recall already excludes the old memory. Everything
+        # below is follow-up. An exception escaping from here would reach
+        # store()'s outer handler, which records SUPERSEDE_FAILED — and that
+        # marker means "did not land AT ALL", which would now be false: the
+        # caller would be told the old memory is probably still live when it is
+        # not. Anything that throws past this line is therefore a PARTIAL, named
+        # as such, and never allowed to escape.
+        degraded: list[str] = []
+        try:
+            degraded.extend(
+                await self._supersede_follow_up(old_id, new_id, timestamp)
+            )
+        except Exception:
+            degraded.append("post_deprecation")
+            logger.warning(
+                "Supersede follow-up failed after the deprecation committed "
+                "(%s -> %s); the SQLite deprecation DID apply",
+                old_id, new_id, exc_info=True,
+            )
+        return degraded
+
+    async def _supersede_follow_up(
+        self,
+        old_id: str,
+        new_id: str,
+        timestamp: str,
+    ) -> list[str]:
+        """The best-effort steps AFTER the SQLite deprecation has committed.
+
+        Split out so the caller can bound them: every failure in here is a
+        PARTIAL (the deprecation already landed), never a total failure.
+        Returns the names of the steps that failed.
+        """
+        degraded: list[str] = []
+
         # Qdrant: look up collection from metadata, then update payload.
         # Only touch Qdrant when a vector actually exists (status 'embedded').
         # 'fts5_only' (subsystem write), 'pending' (embed queued), and 'failed'
@@ -684,6 +754,7 @@ class MemoryStore:
                     payload={"deprecated": True, "merged_into": new_id},
                 )
             except Exception:
+                degraded.append("qdrant_payload")
                 logger.warning(
                     "Qdrant update_payload failed for superseded memory %s",
                     old_id, exc_info=True,
@@ -702,6 +773,7 @@ class MemoryStore:
         except Exception as link_exc:
             # PK collision is fine (link already exists); log unexpected errors
             if "UNIQUE constraint" not in str(link_exc):
+                degraded.append("succeeded_by_link")
                 logger.warning(
                     "Failed to create succeeded_by link %s → %s: %s",
                     old_id, new_id, link_exc,
@@ -722,6 +794,8 @@ class MemoryStore:
                 invalidate_graph_cache()
             except ImportError:
                 pass
+
+        return degraded
 
     async def delete(self, memory_id: str) -> dict:
         """Delete a memory from all layers. Returns per-layer status.

--- a/tests/test_mcp/test_memory_mcp.py
+++ b/tests/test_mcp/test_memory_mcp.py
@@ -2380,3 +2380,70 @@ async def test_memory_store_does_not_report_a_supersede_nobody_asked_for():
             f"supersedes={empty!r} produced a supersede report: {result!r}"
         )
         assert isinstance(result, str), "the bare-id shape is what a non-request returns"
+
+
+@pytest.mark.asyncio()
+async def test_memory_store_reports_a_partially_applied_supersede():
+    """A supersede that half-landed must not report as fully landed.
+
+    The Qdrant payload write and the link create are best-effort and swallow
+    their own exceptions. The vector leg of hybrid recall filters on that
+    Qdrant `deprecated` payload while FTS filters on the SQLite column, so a
+    swallowed payload write leaves the memory hidden from one leg and live in
+    the other — reported, before this, as `superseded: True`.
+    """
+    from genesis.mcp.memory import core
+
+    async def _store_with_degradation(*a, **kw):
+        kw["supersede_degraded"].append("qdrant_payload")
+        return "new-id"
+
+    tools = await _get_tools()
+    with patch.object(core, "_memory_mod") as mod:
+        mod.return_value._store = MagicMock()
+        mod.return_value._store.store = AsyncMock(side_effect=_store_with_degradation)
+        result = await tools["memory_store"].fn(
+            "content", "src", supersedes="abcd1234-0000-4000-8000-000000000001"
+        )
+
+    assert result["memory_id"] == "new-id"
+    assert result["partial"] == ["qdrant_payload"]
+    assert result["superseded"] is True, (
+        "the SQLite deprecation DID land — a partial is not a total failure"
+    )
+    assert "vector recall" in result["warning"]
+
+
+@pytest.mark.asyncio()
+async def test_memory_store_does_not_report_success_for_a_failed_supersede():
+    """An outright supersede failure must not arrive as `superseded: True`.
+
+    The two `except Exception` handlers in ``store()`` catch anything that is
+    not ``SupersedeUnresolved`` — a SQLite fault in resolve_id, mark_superseded
+    or get_metadata — so the exception never reaches this layer. They logged and
+    left the out-param empty, and the unconditional `superseded: True` then told
+    the caller a deprecation that provably had not run had landed. The marker is
+    what distinguishes "threw before the deprecation" from the post-deprecation
+    partials, which legitimately stay `superseded: True`.
+    """
+    from genesis.mcp.memory import core
+    from genesis.memory.store import SUPERSEDE_FAILED
+
+    async def _store_that_failed(*a, **kw):
+        kw["supersede_degraded"].append(SUPERSEDE_FAILED)
+        return "new-id"
+
+    tools = await _get_tools()
+    with patch.object(core, "_memory_mod") as mod:
+        mod.return_value._store = MagicMock()
+        mod.return_value._store.store = AsyncMock(side_effect=_store_that_failed)
+        result = await tools["memory_store"].fn(
+            "content", "src", supersedes="abcd1234-0000-4000-8000-000000000001"
+        )
+
+    assert result["memory_id"] == "new-id", "the content is still durable"
+    assert result["superseded"] is False, (
+        "reported a supersede that threw before touching SQLite as successful"
+    )
+    assert "FAILED" in result["warning"]
+    assert "not be duplicated" in result["warning"], "the retry must stay safe"

--- a/tests/test_memory/test_mcp_integration.py
+++ b/tests/test_memory/test_mcp_integration.py
@@ -80,6 +80,11 @@ async def test_memory_store_delegates(mock_deps, tools):
         room=None,
         collection=None,
         supersedes=None,
+        # Out-param the MCP layer always passes: store() appends the supersede
+        # steps that failed AFTER the SQLite deprecation landed, so a partial
+        # supersede is not reported as a complete one. Empty here because
+        # nothing was superseded.
+        supersede_degraded=[],
     )
 
 

--- a/tests/test_memory/test_supersede_prefix_resolution.py
+++ b/tests/test_memory/test_supersede_prefix_resolution.py
@@ -20,7 +20,7 @@ mocked connection would happily confirm whatever the test asserted.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiosqlite
 import pytest
@@ -360,3 +360,134 @@ async def test_the_normal_path_does_not_pay_for_successor_verification(store, db
 
     assert (await _row(db, OLD))["deprecated"] == 1
     assert (OLD, NEW, "succeeded_by") in await _links(db)
+
+
+# ─── PARTIAL vs TOTAL failure ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio()
+async def test_an_unexpected_supersede_error_is_reported_not_swallowed(store, db):
+    """A supersede that throws something other than SupersedeUnresolved — a
+    SQLite fault in resolve_id / mark_superseded / get_metadata — used to be
+    logged while the out-param stayed empty, and the MCP layer then reported
+    `superseded: True` about a deprecation that provably never ran.
+
+    MEASURED before the fix: target left at deprecated=0, degraded=[].
+    """
+    import aiosqlite as _aiosqlite
+
+    import genesis.memory.store as store_mod
+    from genesis.memory.store import SUPERSEDE_FAILED
+
+    async def boom(*_a, **_k):
+        raise _aiosqlite.OperationalError("database is locked")
+
+    await _index(db, NEW, DUPE)
+    degraded: list[str] = []
+
+    with patch.object(store_mod.memory_crud, "resolve_id", boom):
+        returned = await store.store(
+            DUPE,
+            "conversation",
+            supersedes=OLD,
+            supersede_degraded=degraded,
+        )
+
+    assert returned == NEW, "the store itself must still succeed"
+    assert (await _row(db, OLD))["deprecated"] == 0, "nothing was deprecated"
+    assert SUPERSEDE_FAILED in degraded, (
+        "the failure left no trace, so the report claimed the supersede landed"
+    )
+
+
+@pytest.mark.asyncio()
+async def test_a_failure_after_the_deprecation_commits_is_a_partial(store, db):
+    """`SUPERSEDE_FAILED` means "did not land AT ALL". Anything thrown after
+    `crud.mark_superseded` has COMMITTED makes that false: SQLite recall already
+    excludes the old memory, so reporting a total failure tells the caller the
+    old memory is probably still live when it is not.
+
+    MEASURED before the fix: `get_metadata` raising left `OLD.deprecated=1` and
+    `superseded_by` set, while the exception escaped `_mark_superseded` to
+    store()'s outer handler, which recorded SUPERSEDE_FAILED.
+    """
+    import genesis.memory.store as store_mod
+    from genesis.memory.store import SUPERSEDE_FAILED
+
+    async def boom(*_a, **_k):
+        raise RuntimeError("simulated fault after the commit")
+
+    with patch.object(store_mod.memory_crud, "get_metadata", boom):
+        degraded = await store._mark_superseded(OLD, NEW, "2026-09-06T19:53:21+00:00")
+
+    assert (await _row(db, OLD))["deprecated"] == 1, "the deprecation did commit"
+    assert "post_deprecation" in degraded, "reported as a partial, naming the step"
+    assert SUPERSEDE_FAILED not in degraded, (
+        "a post-commit fault must NOT be classified as a total failure"
+    )
+
+
+@pytest.mark.asyncio()
+async def test_a_swallowed_qdrant_payload_write_is_named(store, db):
+    """The `qdrant_payload` marker, asserted from the real code path.
+
+    `update_payload` swallows its own exception by design — the supersede must
+    not fail because Qdrant is down. But the vector leg of hybrid recall filters
+    on that payload while FTS filters on the SQLite column, so a swallowed write
+    leaves the memory hidden from one leg and live in the other. Naming the step
+    is the only thing that stops that being reported as a complete supersede.
+    """
+    import genesis.memory.store as store_mod
+
+    # Qdrant is only touched for an 'embedded' row — fts5_only skips it, which
+    # is what the rest of this file's fixtures are.
+    await db.execute(
+        "UPDATE memory_metadata SET embedding_status = 'embedded' WHERE memory_id = ?", (OLD,)
+    )
+    await db.commit()
+
+    def boom(*_a, **_k):
+        raise RuntimeError("qdrant unreachable")
+
+    with patch.object(store_mod, "update_payload", boom):
+        degraded = await store._mark_superseded(OLD, NEW, "2026-09-06T19:53:21+00:00")
+
+    assert (await _row(db, OLD))["deprecated"] == 1, "the deprecation still applies"
+    assert degraded == ["qdrant_payload"]
+    assert (OLD, NEW, "succeeded_by") in await _links(db), (
+        "the link step must still run — one failed follow-up does not skip the rest"
+    )
+
+
+@pytest.mark.asyncio()
+async def test_a_failed_succeeded_by_link_is_named(store, db):
+    """The `succeeded_by_link` marker, asserted from the real code path.
+
+    A UNIQUE-constraint failure means the link already exists and is NOT a
+    degradation; anything else is. Both branches are exercised here so the
+    marker cannot be appended unconditionally.
+    """
+    import genesis.memory.store as store_mod
+
+    async def boom(*_a, **_k):
+        raise RuntimeError("link table write failed")
+
+    with patch.object(store_mod.memory_links_crud, "create", boom):
+        degraded = await store._mark_superseded(OLD, NEW, "2026-09-06T19:53:21+00:00")
+
+    assert (await _row(db, OLD))["deprecated"] == 1
+    assert degraded == ["succeeded_by_link"]
+
+    # ...and a UNIQUE collision is not a degradation: the edge is already there.
+    async def already(*_a, **_k):
+        raise RuntimeError("UNIQUE constraint failed: memory_links.source_id")
+
+    await db.execute(
+        "UPDATE memory_metadata SET deprecated = 0, superseded_by = NULL WHERE memory_id = ?",
+        (OLD,),
+    )
+    await db.commit()
+    with patch.object(store_mod.memory_links_crud, "create", already):
+        degraded = await store._mark_superseded(OLD, NEW, "2026-09-06T19:53:21+00:00")
+
+    assert degraded == [], "an existing link is not a partial supersede"

--- a/tests/test_memory/test_supersession.py
+++ b/tests/test_memory/test_supersession.py
@@ -498,7 +498,7 @@ async def test_dedup_short_circuit_still_supersedes(store, db):
          patch("genesis.memory.store.update_payload"), \
          patch("genesis.memory.store.memory_crud") as mock_mem, \
          patch("genesis.memory.store.memory_links_crud") as mock_links, \
-         patch.object(MemoryStore, "_mark_superseded", new=AsyncMock()) as ms:
+         patch.object(MemoryStore, "_mark_superseded", new=AsyncMock(return_value=[])) as ms:
         mock_mem.upsert = AsyncMock(return_value="id")
         mock_mem.resolve_id = AsyncMock(
             side_effect=lambda _db, mid: ([mid], "passthrough")
@@ -600,3 +600,36 @@ async def test_store_lets_an_unresolved_supersede_out(store, db):
     # that is why the MCP layer reports instead of raising to the caller.
     assert exc.value.stored_memory_id
     mock_mem.mark_superseded.assert_not_awaited()
+
+
+@pytest.mark.asyncio()
+async def test_normal_path_records_an_unexpected_supersede_failure(store, db):
+    """The NORMAL supersede path's `except Exception` must report, not just log.
+
+    Twin of the dedup-path case in test_supersede_prefix_resolution. Both
+    handlers exist so a transient failure does not turn a durable store into a
+    raised error — but silence there became `superseded: True` at the MCP layer,
+    about a deprecation that never ran. Covered separately because deleting the
+    append from EITHER handler must produce a RED; one test cannot see both.
+    """
+    from genesis.memory.store import SUPERSEDE_FAILED
+
+    with patch("genesis.memory.store.upsert_point"), \
+         patch("genesis.memory.store.memory_crud") as mock_mem:
+        mock_mem.upsert = AsyncMock(return_value="id")
+        mock_mem.create_metadata = AsyncMock(return_value=None)
+        mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
+        mock_mem.resolve_id = AsyncMock(
+            side_effect=RuntimeError("simulated SQLite fault")
+        )
+        degraded: list[str] = []
+        result = await store.store(
+            "new content", "conversation",
+            supersedes="old-memory-id", supersede_degraded=degraded,
+        )
+
+    assert isinstance(result, str) and len(result) == 36, "the store must survive"
+    assert SUPERSEDE_FAILED in degraded, (
+        "the failure was logged and nothing else — the report would claim the "
+        "supersede landed"
+    )


### PR DESCRIPTION
**Split 4 of 5 from #1831.** Base: `fix/supersede-report-to-caller` (#1930).

> **Stacked**, three deep: `main` → #1928 → #1929 → #1930 → this. It edits the
> report #1930 introduces and both `except Exception` handlers #1929 and #1928
> established. **CI does not run for a non-default base**; targeted suites were
> run locally and are recorded below.

## What this fixes

#1930 made `memory_store` report whether the supersede happened. It derived that
answer from *"nothing raised"*, which is not the same question — two failures
were still reported as success.

**1. A supersede that HALF-applied.** The two steps after the SQLite deprecation
are best-effort and swallow their own exceptions. The vector leg of hybrid recall
filters on the Qdrant `deprecated` payload while the keyword leg filters the
SQLite column, so a swallowed payload write hides the memory from one leg and
leaves it live in the other. `_mark_superseded` now returns the steps that
**failed**, and the report names them in `partial`.

**2. A supersede that failed OUTRIGHT.** Both `except Exception` handlers caught
a database fault in `resolve_id` / `mark_superseded` / `get_metadata`, logged it,
and left the out-param empty; the unconditional `superseded: true` then claimed a
deprecation that provably had not run. A distinct marker makes that case report
`superseded: false`, because the caller's next move depends on whether the old
memory is still live.

## The point of no return

`crud.mark_superseded` commits before it returns, so past that line SQLite recall
already excludes the old memory — a failure after it can never honestly be "did
not land at all". Everything after the commit moved into `_supersede_follow_up`
and is bounded: what throws there is the `post_deprecation` **partial** and can
never escape as a total failure. Without the boundary the caller is told the old
memory is probably still live when recall already hides it, which is the same
class of lie inverted.

`_supersede_follow_up` is a pure extraction — the Qdrant block, the link create,
and the graph-cache invalidation `else:` clause (#1641 work) move together,
unchanged apart from two `degraded.append` lines.

## Found while reviewing this split, not inherited from #1831

The `qdrant_payload` and `succeeded_by_link` markers had **no test that reached
the real appends**. The MCP-level test injects the marker through the mocked
out-param, which proves the report renders it and nothing about whether
`_mark_superseded` ever produces it. **Deleting either append left the suite
green.**

Closed with two tests through real SQLite:

- `test_a_swallowed_qdrant_payload_write_is_named` — flips the target to
  `embedding_status='embedded'` first, because the fixture is `fts5_only` and that
  path **skips Qdrant entirely**, so without it the test would pass vacuously. It
  also asserts the link step still ran: one failed follow-up must not skip the
  rest.
- `test_a_failed_succeeded_by_link_is_named` — asserts **both** branches: an
  arbitrary error is a degradation, a `UNIQUE constraint` error is not (the edge
  already exists). Without the second half the marker could be appended
  unconditionally and stay green.

## Verification

**Verify-RED — 7 mutations, all applied, all biting.**

| mutation | red test |
|---|---|
| drop the `qdrant_payload` append | `test_a_swallowed_qdrant_payload_write_is_named` |
| drop the `succeeded_by_link` append | `test_a_failed_succeeded_by_link_is_named` |
| normal path stops recording an outright failure | `test_normal_path_records_an_unexpected_supersede_failure` |
| dedup path stops recording an outright failure | `test_an_unexpected_supersede_error_is_reported_not_swallowed` |
| remove the point-of-no-return boundary | `test_a_failure_after_the_deprecation_commits_is_a_partial` |
| an outright failure keeps `superseded: true` | `test_memory_store_does_not_report_success_for_a_failed_supersede` |
| drop the `partial` list | `test_memory_store_reports_a_partially_applied_supersede` |

Rows 3 and 4 fail **different** tests, verified individually — there are two
handlers and one test cannot reach both.

- 134 targeted tests green; `ruff` clean.
- A post-deprecation partial deliberately keeps `superseded: true` (the
  deprecation DID land); only the outright-failure marker flips it. A test
  asserts that `true` explicitly, so a later "simplification" flipping every
  partial to `false` goes red.
- An out-param rather than a wider return type, because `store()` returns the
  memory id at ~every call site in the tree; `supersede_degraded` is `None`
  everywhere except the one MCP call site, and every append is guarded.

## Not fixed here

Locating the Qdrant point across collections before claiming the payload update
applied. The guard it concerns (`embedding_status == 'embedded'`) is untouched by
this stack, and the remedy is new per-supersede Qdrant I/O.

E2E: with Qdrant stopped, `memory_store(supersedes=<id of an embedded memory>)` via MCP — confirm the response carries `partial: ["qdrant_payload"]` with `superseded: true` (the SQLite deprecation did land), rather than a bare success.
