### PR TITLE
docs(review): ask the reviewer whether the approach is right, not only the code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,26 @@ not to confirm:
   verdict ("remaining items are out-of-threat-model residue, not blocking") instead of
   continuing to enumerate: over-hardening code whose functionality doesn't warrant it is
   itself a review failure.
+- **"The approach itself is wrong" is a legitimate review verdict — say it when the
+  evidence supports it.** Rounds accumulate for two different reasons and the round
+  count cannot tell them apart: a sound solution carrying defects converges, while a
+  WRONG-SHAPED solution does not — each fix creates the surface for the next finding,
+  so the loop reads like whack-a-mole while it is really a design error accruing
+  interest. You are the only reviewer positioned to notice, because the author has
+  three rounds of sunk cost and the read-model that produced the design.
+  Three signals, none of which requires you to judge intent — all are visible in the
+  diff and the review history:
+  * findings CONCENTRATE in one file or one function rather than scattering;
+  * a finding lands on a line THIS pull request itself added in an earlier round
+    (the fix is generating its own bug supply);
+  * the diff GROWS across rounds instead of shrinking.
+  When two or more hold, say so plainly and name the alternative shape — delete the
+  mechanism, move it one layer up, make the problem impossible rather than detected.
+  A denylist defeated by a caller does not become correct by enumerating callers.
+  Scope it honestly, because the opposite error is just as expensive: findings that
+  SCATTER across a diff, each with a local fix, are ordinary defects in a sound
+  design, and telling that author their architecture is wrong sends them hunting a
+  problem that is not there. Absent the signals, review the code.
 - **End with a verdict:** `Ready to merge: Yes | No | With fixes` + a one-line reason.
 
 ### Documentation is out of scope for review

--- a/changelog.d/20260910194023-added-review-premise-mandate.md
+++ b/changelog.d/20260910194023-added-review-premise-mandate.md
@@ -1,0 +1,1 @@
+- The cross-model reviewer is now asked whether the approach is right, not only whether the code is. It was previously told to hunt defects and nothing else, so a solution that was wrong in shape produced round after round of real findings with nobody ever saying why they kept coming.


### PR DESCRIPTION
The cross-model review mandate in `AGENTS.md` tells the reviewer to assume bugs,
enumerate the class, read authoritative semantics, and calibrate severity to the
declared threat model. **Every bullet is about finding defects.** None asks
whether the thing being defended should exist — so the reviewer has never been
asked that question, and we then treated its silence as a property of the model.

**Why `AGENTS.md` and not the skill.** It is the one prompt surface the GitHub
reviewer demonstrably reads: MEASURED on #1907, **11 of 14** findings carried an
explicit `AGENTS.md reference: AGENTS.md:L##-L##` citation. Grep the mandate for
premise / approach / root-cause / should-this-exist — nothing.

**What it adds.** Rounds accumulate for two reasons the count cannot separate. A
sound solution carrying defects converges; a wrong-shaped one does not — each fix
creates the surface for the next finding, so the loop reads like whack-a-mole
while it is a design error accruing interest. The reviewer is the only participant
positioned to notice: the author holds three rounds of sunk cost and the
read-model that produced the design.

The verdict is gated on three things visible in the diff and review history, not
on judgement about intent:

- findings **concentrate** in one file/function rather than scattering
- a finding lands on a line **this PR itself added** in an earlier round
- the diff **grows** across rounds instead of shrinking

Two or more, and the reviewer is asked to say so and name the alternative shape.

**And the opposite error is stated, because it costs as much.** Findings that
scatter, each with a local fix, are ordinary defects in a sound design — telling
that author their architecture is wrong sends them hunting a problem that isn't
there. Absent the signals, review the code.

## Honest confidence: ~45% that this works

That Codex *reads* this file is measured. That a third-party model *uses a new
bullet well* is not, and cannot be before shipping. This is deliberately **one
file** so the before/after is attributable — bundling it with the
instruction-file reconciliation (#1938) would have made any behaviour change
impossible to attribute. The separation is the experiment.

Falsifier: if the next few PRs produce the same defect-only findings with no
shape verdict where the signals are present, the seat is implicated rather than
the prompt, and the model-interchangeability question becomes the real one.

Design of record: §H / §H.1 of the review-policy redesign spec (local).

E2E: none — instruction prose, no runtime surface.
