### PR TITLE
fix(ci): dependency-audit reports, it does not block

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,8 @@
 # fastmcp <3 for API stability, transitive secure floors) that automatic
 # version-update PRs would fight. GitHub's Dependabot *security* alerts are
 # already enabled for the repo and cover the pip CVE side; the pip-audit CI job
-# gates the resolved tree per-PR. So dependabot only keeps the Actions current.
+# reports on the resolved tree per-PR without blocking on audit findings.
+# Dependabot version updates here only keep the Actions current.
 version: 2
 updates:
   - package-ecosystem: "github-actions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
   dependency-audit:
     # REPORTS known-vulnerable dependencies in the resolved runtime tree. It no
-    # longer FAILS the workflow — see continue-on-error below, which is the whole
+    # longer FAILS — see the step-level continue-on-error below, which is the whole
     # point of this job's current shape.
     #
     # It used to be a blocking check whose red run was "a SIGNAL to bump the dep
@@ -69,9 +69,6 @@ jobs:
     # they were judged unreachable; deleting it would discard that reasoning and
     # bury the genuinely-new IDs in a wall of known ones.
     runs-on: ubuntu-latest
-    # Report, never block. Job-level, so a failing pip-audit leaves the job green
-    # in the rollup instead of taking the CI workflow red with it.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
@@ -83,9 +80,19 @@ jobs:
           pip install -e .
           pip install pip-audit
       - name: Audit dependencies for known CVEs
+        # STEP level, not job level, and the difference is the whole mechanism.
+        # MEASURED on this PR's own first run: with `continue-on-error` on the
+        # JOB, the workflow no longer fails but the job's own check-run
+        # conclusion is still `failure`, so `gh pr checks` and the merge gate
+        # both still read it red — the block was unchanged. On the STEP, a
+        # failing pip-audit does not fail the job, so the rollup entry is green
+        # and the advisories are still printed in the log above it.
+        continue-on-error: true
         run: |
           # Triaged --ignore-vuln IDs (rationale of record: pyproject.toml pins).
-          # A NEW / untriaged advisory is NOT in this list and so fails the job.
+          # A NEW / untriaged advisory is NOT in this list, so it is REPORTED here —
+          # it no longer fails the job (see continue-on-error above). The list is
+          # kept so a genuinely-new ID stands out from the known ones.
           #   litellm 1.78.7 — every ID is a proxy-server / JWT / OIDC / UI /
           #     MCP-gateway vuln; Genesis uses acompletion/completion_cost only
           #     (no proxy server), so none are reachable. Pinned <1.83 also dodges

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,9 @@ jobs:
     #
     # NOTE the triaged --ignore-vuln list below is deliberately KEPT rather than
     # deleted. It is the written record of which advisories were examined and why
-    # they were judged unreachable; deleting it would discard that reasoning and
-    # bury the genuinely-new IDs in a wall of known ones.
+    # they were judged unreachable; deleting it would discard that reasoning.
+    # This reporting-policy change adds no new ignores: the four IDs discussed
+    # above remain visible, along with any other ID outside the existing baseline.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -91,8 +92,8 @@ jobs:
         run: |
           # Triaged --ignore-vuln IDs (rationale of record: pyproject.toml pins).
           # A NEW / untriaged advisory is NOT in this list, so it is REPORTED here —
-          # it no longer fails the job (see continue-on-error above). The list is
-          # kept so a genuinely-new ID stands out from the known ones.
+          # it no longer fails the job (see continue-on-error above). Existing
+          # ignores reduce log noise; all IDs outside that baseline stay visible.
           #   litellm 1.78.7 — every ID is a proxy-server / JWT / OIDC / UI /
           #     MCP-gateway vuln; Genesis uses acompletion/completion_cost only
           #     (no proxy server), so none are reachable. Pinned <1.83 also dodges

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,39 @@ jobs:
         run: ruff check src/ tests/ scripts/
 
   dependency-audit:
-    # Fail on any KNOWN-vulnerable dependency in the resolved runtime tree,
-    # except the triaged IDs below. A red run is a SIGNAL to bump the dep or
-    # add a triaged ignore — not a hard freeze (the ruleset has no required
-    # checks). Complements GitHub's already-enabled Dependabot security alerts.
+    # REPORTS known-vulnerable dependencies in the resolved runtime tree. It no
+    # longer FAILS the workflow — see continue-on-error below, which is the whole
+    # point of this job's current shape.
+    #
+    # It used to be a blocking check whose red run was "a SIGNAL to bump the dep
+    # or add a triaged ignore". In practice the signal arrived as a repo-wide
+    # outage: pip-audit queries a LIVE advisory database, so an unchanged
+    # dependency tree passes at one hour and fails the next, on every open PR at
+    # once, with nobody having changed a line. MEASURED 2026-09-10/11: main's CI
+    # passed this job at 18:41 EDT; by 23:30 the same tree failed it on four
+    # different branches simultaneously. The four new IDs were litellm
+    # CVE-2026-12771/12772/12773/12795, every one of them in `litellm/proxy/` —
+    # the same proxy-server class as the 28 already triaged below, and Genesis
+    # imports acompletion / completion_cost / model_cost / the exception types
+    # and references the proxy NOWHERE (verified across src/, scripts/, config/
+    # and pyproject.toml).
+    #
+    # So the blocking behaviour was not catching reachable vulnerabilities; it
+    # was converting third-party disclosure timing into an unplanned freeze of
+    # everyone's queue, repaired each time by appending another ignore. The
+    # advisories are still printed in the log, and GitHub's Dependabot security
+    # alerts — enabled on this repo — remain the mechanism that actually raises a
+    # vulnerability to a human. This job is the convenience view of the same
+    # data, and a convenience view must not hold the merge queue.
+    #
+    # NOTE the triaged --ignore-vuln list below is deliberately KEPT rather than
+    # deleted. It is the written record of which advisories were examined and why
+    # they were judged unreachable; deleting it would discard that reasoning and
+    # bury the genuinely-new IDs in a wall of known ones.
     runs-on: ubuntu-latest
+    # Report, never block. Job-level, so a failing pip-audit leaves the job green
+    # in the rollup instead of taking the CI workflow red with it.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -287,8 +287,10 @@ source — there is no `requirements.txt`). Known-CVE scanning runs automaticall
 
 - **CI** — the `dependency-audit` job in `.github/workflows/ci.yml` runs
   `pip-audit` against the resolved runtime tree on every PR/push and weekly,
-  failing on any new (untriaged) advisory. Already-triaged, not-reachable
-  advisories are listed with rationale in that job.
+  reporting advisories outside its retained ignore baseline in the job log.
+  Audit findings are advisory: step-level `continue-on-error` prevents them
+  from failing the job. Dependency installation failures still fail the job.
+  Existing ignored advisories are listed with rationale in that job.
 - **Dependabot** — GitHub's dependency-graph security alerts are enabled for
   the repo, and `.github/dependabot.yml` keeps the GitHub Actions current.
 


### PR DESCRIPTION
`dependency-audit` stops being able to block the merge queue. It still runs, still
installs the tree, still runs `pip-audit`, and still prints every advisory.

E2E: this PR's own CI run is the experiment — see "the one assumption" below.

## Why

`pip-audit` queries a **live** advisory database, so an unchanged dependency tree
passes at one hour and fails the next, on every open PR simultaneously, with nobody
having changed a line.

MEASURED 2026-09-10/11:

- main's CI passed this job at **18:41 EDT** (run `34515891822`, SUCCESS)
- by **23:30** the same tree failed it repo-wide. Enumerated rather than sampled:
  **25 of the 25 most recent completed CI runs carrying this job are failing it**,
  across roughly ten branches. (A second session independently enumerated 20 of 20
  over a smaller window.)
- none of those branches touches `pyproject.toml`, `requirements*`, or a lock file,
  so the resolved tree is identical to the commit that passed
- main reads green only because its last CI run *predates* the advisories — nothing
  has re-run on main since, so "main is green" is stale rather than current

Reproducing CI's own step locally (fresh venv, editable install, then `pip-audit` with
the exact `--ignore-vuln` list):

```
Found 4 known vulnerabilities, ignored 28 in 1 package
litellm 1.78.7  CVE-2026-12771
litellm 1.78.7  CVE-2026-12772
litellm 1.78.7  CVE-2026-12773  (fix 1.84.0)
litellm 1.78.7  CVE-2026-12795
```

All four are in `litellm/proxy/` — M2M JWT handler, PROXY_ADMIN key generator, MCP
proxy, SSO debug flow. That is the same proxy-server class as the 28 already triaged
in this file. Genesis's entire litellm surface is `acompletion`, `completion_cost`,
`model_cost`, `Timeout` and the exception types, and there is **no reference to the
proxy anywhere** in `src/`, `scripts/`, `config/` or `pyproject.toml`. None is
reachable.

A bump is not available as the fix: the pin is exact (`litellm==1.78.7`), the only
offered fix is `1.84.0`, and the pin's own comment records that 1.82.7/1.82.8 carry
malware.

So the blocking behaviour was not catching reachable vulnerabilities. It was turning
third-party disclosure timing into an unplanned queue freeze, repaired each time by
appending one more ignore — a treadmill, not a gate.

## What is given up

Stated rather than minimised: a genuinely reachable vulnerability would now be printed
in a log nobody is required to read, instead of stopping a merge.

Two things bound that, and neither makes it costless:

- **This was never a server-side required check.** `gh api repos/.../rulesets` →
  "Genesis Required Checks" requires exactly `test`, `leak-detector`, `lint`. GitHub
  would already merge a PR with this job red; only the local merge gate objected. This
  aligns the local gate with the policy already in force. (`main` is not
  branch-protected at all — `branches/main/protection` returns 404 — so that ruleset
  is the *only* server-side constraint there is.)
- **Dependabot security alerts are enabled** and remain the mechanism that actually
  raises a vulnerability to a human. (The push for this very branch printed
  *"GitHub found 4 vulnerabilities on the default branch"* — the same four.)

One entry in the existing ignore list deserves naming, because it is the least robust
and this PR should not quietly inherit it. `CVE-2026-37004` (= `GHSA-6wvf-77m9-58rm`)
is **CRITICAL** — unauthenticated SSTI to arbitrary OS command execution via an
unsandboxed `jinja2.Environment` in the `/prompts/test` endpoint. It is a proxy
endpoint, so the reachability argument does hold; but for that entry reachability is
doing *all* the work, and its fix (1.83.7) is past the 1.82.x malware the exact pin
exists to avoid. If anyone later concludes the pin can move, that is the entry to
re-examine first. Flagged by a second session reviewing this change.

The `--ignore-vuln` list is **kept**, not deleted: it is the written record of which
advisories were examined and why they were judged unreachable, and removing it would
bury a genuinely-new ID among 28 known ones.

## The assumption was tested, falsified once, and then confirmed

Recorded here because this PR made a falsifiable prediction and the falsifier fired.

**Revision 1 put `continue-on-error` on the JOB.** Prediction: the rollup entry goes
green. MEASURED on run `34621880657` — it did **not**:

```
gh run view --json jobs   -> dependency-audit conclusion = failure
gh pr checks 1960         -> dependency-audit  fail
git_push_guard --check-pr -> ci : red (dependency-audit)
```

Job-level `continue-on-error` stops the *workflow* failing but leaves the job's own
check-run conclusion at `failure` — which is exactly what `gh pr checks` and the merge
gate read. The block was unchanged.

**Revision 2 moved it to the STEP.** MEASURED on run `34623487133`:

```
gh pr checks 1960         -> dependency-audit  pass   (43s)
job conclusion            -> success
git_push_guard --check-pr -> ci : pending (test)      # audit no longer named
```

Stated precisely, because the two are different claims: what is MEASURED is that the
step executed (present in the step list, not skipped) and the job is green. That the
advisories are still *printed* is INFERRED rather than read — `continue-on-error`
changes only how a non-zero exit is treated, not what pip-audit does, and the job's
43s runtime matches the failing runs' 45s/54s rather than a skip. The job-log API
returns an empty body for this job, so the advisory lines could not be read back
directly.

If that inference ever matters to someone, the check is to run pip-audit locally with
this file's `--ignore-vuln` list — which is how the four CVEs above were identified in
the first place.
